### PR TITLE
feat: API 공통 응답 및 전역 예외 처리 설정 (#15)

### DIFF
--- a/backend/src/main/java/com/rungo/api/global/exception/CustomException.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/CustomException.java
@@ -1,0 +1,10 @@
+package com.rungo.api.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.rungo.api.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 공통
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러가 발생했습니다."),
+
+    // 유저, 인증
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+
+    // 마라톤, 접수
+    MARATHON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마라톤 대회를 찾을 수 없습니다."),
+    CAPACITY_FULL(HttpStatus.BAD_REQUEST, "마라톤 참가 정원이 마감되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,74 @@
+package com.rungo.api.global.exception;
+
+import com.rungo.api.global.response.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 1. 비즈니스 예외 처리 (CustomException)
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        log.warn("Business Exception: {}", e.getErrorCode().getMessage());
+        ErrorCode ec = e.getErrorCode();
+
+        return ResponseEntity.status(ec.getStatus())
+                             .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
+    }
+
+    // 2. 입력값 검증 실패 처리 (@Valid RequestBody)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn("Validation Exception 발생");
+        Map<String, String> errors = new HashMap<>();
+
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            // 중복 필드 에러 덮어쓰기 방지
+            errors.putIfAbsent(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        // ErrorCode 재사용
+        ErrorCode ec = ErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity.status(ec.getStatus())
+                             .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage(), errors));
+    }
+
+    // 3. 파라미터 검증 실패 처리 (@Validated RequestParam, PathVariable)
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ApiResponse<Map<String, String>>> handleConstraintViolationException(ConstraintViolationException e) {
+        log.warn("ConstraintViolationException 발생");
+        Map<String, String> errors = new HashMap<>();
+
+        e.getConstraintViolations().forEach(violation -> {
+            String propertyPath = violation.getPropertyPath().toString();
+            String fieldName = propertyPath.substring(propertyPath.lastIndexOf('.') + 1);
+            // 중복 방지
+            errors.putIfAbsent(fieldName, violation.getMessage());
+        });
+
+        // ErrorCode 재사용
+        ErrorCode ec = ErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity.status(ec.getStatus())
+                             .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage(), errors));
+    }
+
+    // 4. 시스템 에러 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Internal Server Error: ", e);
+
+        ErrorCode ec = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(ec.getStatus())
+                             .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/rungo/api/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/rungo/api/global/response/ApiResponse.java
@@ -37,7 +37,7 @@ public class ApiResponse<T> {
         return new ApiResponse<>(status.value(), code, message, null);
     }
 
-    // 에러 - 상세 데이터 ex) 검증 에러 목록
+    // 에러 - 상세 데이터 ex) 검증 실패 시 데이터
     public static <T> ApiResponse<T> error(HttpStatus status, String code, String message, T data) {
         return new ApiResponse<>(status.value(), code, message, data);
     }

--- a/backend/src/main/java/com/rungo/api/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/rungo/api/global/response/ApiResponse.java
@@ -1,0 +1,44 @@
+package com.rungo.api.global.response;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiResponse<T> {
+
+    private int status;
+    private String code;
+    private String message;
+    private T data;
+
+    // 성공 - 데이터/메세지 0
+    public static <T> ApiResponse<T> success(HttpStatus status, String message, T data){
+        return new ApiResponse<>(status.value(), "SUCCESS", message, data);
+    }
+
+    // 성공 - 데이터 x
+    public static <T> ApiResponse<T> success(HttpStatus status, String message) {
+        return new ApiResponse<>(status.value(), "SUCCESS", message, null);
+    }
+
+    // 성공
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), "SUCCESS", "요청에 성공했습니다.", data);
+    }
+
+    // 에러 - 데이터 x, 코드/메세지 o
+    public static <T> ApiResponse<T> error(HttpStatus status, String code, String message) {
+        return new ApiResponse<>(status.value(), code, message, null);
+    }
+
+    // 에러 - 상세 데이터 ex) 검증 에러 목록
+    public static <T> ApiResponse<T> error(HttpStatus status, String code, String message, T data) {
+        return new ApiResponse<>(status.value(), code, message, data);
+    }
+}

--- a/backend/src/main/java/com/rungo/api/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/rungo/api/global/response/ApiResponse.java
@@ -1,6 +1,5 @@
 package com.rungo.api.global.response;
 
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,8 +7,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ApiResponse<T> {
 
     private int status;
@@ -17,28 +16,31 @@ public class ApiResponse<T> {
     private String message;
     private T data;
 
-    // 성공 - 데이터/메세지 0
-    public static <T> ApiResponse<T> success(HttpStatus status, String message, T data){
-        return new ApiResponse<>(status.value(), "SUCCESS", message, data);
-    }
-
-    // 성공 - 데이터 x
-    public static <T> ApiResponse<T> success(HttpStatus status, String message) {
-        return new ApiResponse<>(status.value(), "SUCCESS", message, null);
-    }
-
-    // 성공
+    // 1. 조회 성공 (200 OK + 데이터 반환)
+    // 사용 예시: return ResponseEntity.ok(ApiResponse.ok(userDto));
     public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(HttpStatus.OK.value(), "SUCCESS", "요청에 성공했습니다.", data);
     }
 
-    // 에러 - 데이터 x, 코드/메세지 o
-    public static <T> ApiResponse<T> error(HttpStatus status, String code, String message) {
-        return new ApiResponse<>(status.value(), code, message, null);
+    // 2. 생성 성공 (201 Created + 커스텀 메시지 + 데이터 반환)
+    // 사용 예시: return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("회원가입 성공", data));
+    public static <T> ApiResponse<T> created(String message, T data) {
+        return new ApiResponse<>(HttpStatus.CREATED.value(), "SUCCESS", message, data);
     }
 
-    // 에러 - 상세 데이터 ex) 검증 실패 시 데이터
+    // 3. 데이터 없는 성공 (200 OK + 커스텀 메시지 반환)
+    // 사용 예시: return ResponseEntity.ok(ApiResponse.okMessage("접수가 취소되었습니다."));
+    public static ApiResponse<Void> okMessage(String message) {
+        return new ApiResponse<>(HttpStatus.OK.value(), "SUCCESS", message, null);
+    }
+
+    // 4. 에러 응답 (상세 검증 에러 데이터 포함용)
     public static <T> ApiResponse<T> error(HttpStatus status, String code, String message, T data) {
         return new ApiResponse<>(status.value(), code, message, data);
+    }
+
+    // 5. 에러 응답 (기본)
+    public static ApiResponse<Void> error(HttpStatus status, String code, String message) {
+        return new ApiResponse<>(status.value(), code, message, null);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #15 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] `ApiResponse` 구현
    - 성공 메서드 3가지로 분리(`ok, created, okMessage`)


- [x] `ErrorCode, CustomException` 구현
    - 상태 코드와 메시지 `Enum` 출력


- [x] `GlobalExceptionHandler` 구현
    - 비즈니스 에러 발생 시 지정된 `ErrorCode` 규격으로 응답
    - `@valid, @validated `검증 실패 시 `data` 필드에 상세 필드 에러(`Map<String, String>`) 전달 
    - 동일 필드 중복 에러 발생 시 `putIfAbsent` 사용, 첫 번째 에러만 반환

## 🎯 리뷰 포인트


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?