### PR TITLE
feat: Entity 생성자 추가, 서비스 로직,예외 처리 (#25)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
@@ -34,4 +34,16 @@ public class Course {
     @Column(nullable = false)
     private Integer currentCount;
 
+    public Course(
+            String courseType,
+            BigDecimal price,
+            Integer capacity,
+            Integer currentCount
+    ) {
+        this.courseType = courseType;
+        this.price = price;
+        this.capacity = capacity;
+        this.currentCount = currentCount;
+    }
+
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
@@ -73,6 +73,7 @@ public class Marathon {
         this.registrationStartAt = registrationStartAt;
         this.registrationEndAt = registrationEndAt;
         this.status = status;
+        this.createdAt = LocalDateTime.now();
     }
     public void addCourse(Course course){
         this.courses.add(course);

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
@@ -55,6 +55,25 @@ public class Marathon {
     @OneToMany(mappedBy = "marathon", cascade =  CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Course> courses = new ArrayList<>();
 
+    public Marathon(
+            Users organizer,
+            String title,
+            String region,
+            LocalDate eventDate,
+            String posterImageUrl,
+            LocalDateTime registrationStartAt,
+            LocalDateTime registrationEndAt,
+            MarathonStatus status
+    ) {
+        this.organizer = organizer;
+        this.title = title;
+        this.region = region;
+        this.eventDate = eventDate;
+        this.posterImageUrl = posterImageUrl;
+        this.registrationStartAt = registrationStartAt;
+        this.registrationEndAt = registrationEndAt;
+        this.status = status;
+    }
     public void addCourse(Course course){
         this.courses.add(course);
         course.setMarathon(this);

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -16,6 +18,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Marathon {
 
     @Id
@@ -73,7 +76,6 @@ public class Marathon {
         this.registrationStartAt = registrationStartAt;
         this.registrationEndAt = registrationEndAt;
         this.status = status;
-        this.createdAt = LocalDateTime.now();
     }
     public void addCourse(Course course){
         this.courses.add(course);

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -27,12 +27,12 @@ public class MarathonService {
         if (organizer == null) {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
-
-
         // 주최자 측 인가 확인
-        if (organizer.getRole() != Role.ORGANIZER) {
+        else if (organizer.getRole() != Role.ORGANIZER) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
+
+
 
         // 대회 접수 시작일이 종료일보다 이후이면 예외 처리
         if (req.registrationStartAt().isAfter(req.registrationEndAt())) {
@@ -81,6 +81,9 @@ public class MarathonService {
 
     // 5k -> 5K, 10k -> 10K, " 5k " -> 5K 로 저장하기 위해 정규화하는 함수
     private String normalizeCourseType(String courseType) {
+        if (courseType == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
         return courseType.trim().toUpperCase();
     }
 

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -31,7 +31,7 @@ public class MarathonService {
 
         // 주최자 측 인가 확인
         if (organizer.getRole() != Role.ORGANIZER) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
         // 대회 접수 시작일이 종료일보다 이후이면 예외 처리

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -1,0 +1,87 @@
+package com.rungo.api.domain.marathon.marathon.service;
+
+import com.rungo.api.domain.marathon.course.entity.Course;
+import com.rungo.api.domain.marathon.marathon.dto.CreateMarathonReq;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class MarathonService {
+    private final MarathonRepository marathonRepository;
+
+    @Transactional
+    public Marathon createMarathon(Users organizer, CreateMarathonReq req) {
+
+        // 주최하는 사람이 존재하는지 확인
+        if (organizer == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+
+        // 주최자 측 인가 확인
+        if (organizer.getRole() != Role.ORGANIZER) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 대회 접수 시작일이 종료일보다 이후이면 예외 처리
+        if (req.registrationStartAt().isAfter(req.registrationEndAt())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 대회 개최일이 종료일 보다 이전이면 예외 처리
+        if (req.eventDate().isBefore(req.registrationEndAt().toLocalDate())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        //코스 타입 중복이면 예외 처리
+        Set<String> courseTypes = new HashSet<>();
+        for (CreateMarathonReq.CreateCourseItemReq courseReq : req.courses()) {
+
+
+            if (!courseTypes.add(normalizeCourseType(courseReq.courseType()))) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
+        Marathon marathon = new Marathon(
+                organizer,
+                req.title(),
+                req.region(),
+                req.eventDate(),
+                req.posterImageUrl(),
+                req.registrationStartAt(),
+                req.registrationEndAt(),
+                MarathonStatus.OPEN
+        );
+
+        for (CreateMarathonReq.CreateCourseItemReq courseReq : req.courses()) {
+            Course course = new Course(
+                    normalizeCourseType(courseReq.courseType()),
+                    courseReq.price(),
+                    courseReq.capacity(),
+                    0
+            );
+
+            marathon.addCourse(course);
+        }
+
+        return marathonRepository.save(marathon);
+    }
+
+
+    // 5k -> 5K, 10k -> 10K, " 5k " -> 5K 로 저장하기 위해 정규화하는 함수
+    private String normalizeCourseType(String courseType) {
+        return courseType.trim().toUpperCase();
+    }
+
+}

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     // 마라톤, 접수
     MARATHON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마라톤 대회를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] Marathon, Course Entity에 생성자 추가
- [x] 대회 등록 로직 구현
- [x] 주최자 측 역할 인가 예외처리
- [x] 기간 오류 예외 처리
- [x] 코스 등록시 정규화 함수 작성


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
원활한 코드 리뷰를 위해, 예외 상황에다 주석을 달았습니다. 삭제 하는게 낫다 싶으시면 코멘트 남겨주시면 감사하겠습니다.
제가 산정한 예외 상황에 알맞는 에러 코드가 조금 부족하여 INVALID_INPUT_VALUE 를 많이 사용하였는데,
FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."), 를 ErrorCode에 추가하는것은 어떤지 의견 남깁니다.
(해당 오류는 403 에러입니다)


-추가 수정
Marathon Entity에서 생성자로 직접 생성일시를 넣었습니다 해당 코드:(this.createdAt = LocalDateTime.now();)
 
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?