### PR TITLE
feat: registration 접수 생성 서비스 구현 (#23)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
@@ -46,4 +46,11 @@ public class Course {
         this.currentCount = currentCount;
     }
 
+    public boolean isFull() {
+        return currentCount >= capacity;
+    }
+
+    public void increaseCurrentCount() {
+        this.currentCount++;
+    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/dto/CancelRegistrationRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/dto/CancelRegistrationRes.java
@@ -2,8 +2,6 @@ package com.rungo.api.domain.registration.dto;
 
 import com.rungo.api.domain.registration.entity.Registration;
 
-import java.time.LocalDateTime;
-
 public record CancelRegistrationRes(
 
         Long registrationId,
@@ -11,8 +9,7 @@ public record CancelRegistrationRes(
         String marathonTitle,
         Long courseId,
         String courseType,
-        String status,
-        LocalDateTime canceledAt
+        String status
 
 ) {
     public static CancelRegistrationRes from(Registration registration) {
@@ -22,8 +19,7 @@ public record CancelRegistrationRes(
                 registration.getMarathon().getTitle(),
                 registration.getCourse().getId(),
                 registration.getCourse().getCourseType(),
-                registration.getStatus().name(),
-                registration.getCanceledAt()
+                registration.getStatus().name()
         );
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/dto/CreateRegistrationReq.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/dto/CreateRegistrationReq.java
@@ -1,5 +1,6 @@
 package com.rungo.api.domain.registration.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -8,6 +9,7 @@ public record CreateRegistrationReq(
         @NotBlank String snapZipCode,
         @NotBlank String snapAddress,
         String snapDetail,
-        @NotBlank String tSize
+        @NotBlank String tSize,
+        @AssertTrue boolean agreedTerms
 ) {
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
@@ -67,9 +67,57 @@ public class Registration {
     @CreatedDate
     private LocalDateTime appliedAt;
 
-    @Column(name = "canceled_at")
-    private LocalDateTime canceledAt;
-
     @Column(name = "agreed_terms", nullable = false)
     private boolean agreedTerms;
+
+    private Registration(
+            Users user,
+            Course course,
+            Marathon marathon,
+            RegistrationStatus status,
+            String snapName,
+            String snapPhoneNumber,
+            String snapZipCode,
+            String snapAddress,
+            String snapDetail,
+            String tSize,
+            boolean agreedTerms
+    ) {
+        this.user = user;
+        this.course = course;
+        this.marathon = marathon;
+        this.status = status;
+        this.snapName = snapName;
+        this.snapPhoneNumber = snapPhoneNumber;
+        this.snapZipCode = snapZipCode;
+        this.snapAddress = snapAddress;
+        this.snapDetail = snapDetail;
+        this.tSize = tSize;
+        this.agreedTerms = agreedTerms;
+    }
+
+    public static Registration create(
+            Users user,
+            Course course,
+            Marathon marathon,
+            String snapZipCode,
+            String snapAddress,
+            String snapDetail,
+            String tSize,
+            boolean agreedTerms
+    ) {
+        return new Registration(
+                user,
+                course,
+                marathon,
+                RegistrationStatus.COMPLETED,
+                user.getName(),
+                user.getPhoneNumber(),
+                snapZipCode,
+                snapAddress,
+                snapDetail,
+                tSize,
+                agreedTerms
+        );
+    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationService.java
@@ -1,0 +1,72 @@
+package com.rungo.api.domain.registration.service;
+
+import com.rungo.api.domain.marathon.course.entity.Course;
+import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
+import com.rungo.api.domain.registration.dto.CreateRegistrationRes;
+import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.repository.RegistrationRepository;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RegistrationService {
+
+    private final RegistrationRepository registrationRepository;
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+
+    public CreateRegistrationRes create(Long loginUserId, CreateRegistrationReq request) {
+
+        Users user = userRepository.findById(loginUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Course course = courseRepository.findById(request.courseId())
+                .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
+        Marathon marathon = course.getMarathon();
+        LocalDateTime now = LocalDateTime.now();
+
+        // 필수 약관 미동의
+        if (!request.agreedTerms()) {
+            throw new CustomException(ErrorCode.REGISTRATION_TERMS_REQUIRED);
+        }
+        // 접수 기간이 아니면 생성할 수 없다.
+        if (now.isBefore(marathon.getRegistrationStartAt()) || now.isAfter(marathon.getRegistrationEndAt())) {
+            throw new CustomException(ErrorCode.REGISTRATION_PERIOD_INVALID);
+        }
+        // 모집 중인 대회만 접수 가능하다.
+        if (marathon.getStatus() != MarathonStatus.OPEN) {
+            throw new CustomException(ErrorCode.MARATHON_NOT_OPEN);
+        }
+        // 코스 정원이 가득 찼으면 접수를 막는다.
+        if (course.isFull()) {
+            throw new CustomException(ErrorCode.CAPACITY_FULL);
+        }
+
+        Registration registration = Registration.create(
+                user,
+                course,
+                marathon,
+                request.snapZipCode(),
+                request.snapAddress(),
+                request.snapDetail(),
+                request.tSize(),
+                request.agreedTerms()
+        );
+
+        course.increaseCurrentCount();
+        Registration savedRegistration = registrationRepository.save(registration);
+
+        return CreateRegistrationRes.from(savedRegistration);
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/repository/UserRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.rungo.api.domain.users.repository;
+
+import com.rungo.api.domain.users.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<Users, Long> {
+    Optional<Users> findByEmail(String email);
+}

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -20,6 +20,11 @@ public enum ErrorCode {
 
     // 마라톤, 접수
     MARATHON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마라톤 대회를 찾을 수 없습니다."),
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 코스를 찾을 수 없습니다."),
+    REGISTRATION_PERIOD_INVALID(HttpStatus.BAD_REQUEST, "접수 가능 기간이 아닙니다."),
+    MARATHON_NOT_OPEN(HttpStatus.BAD_REQUEST, "현재 접수 가능한 대회 상태가 아닙니다."),
+    REGISTRATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 접수한 대회입니다."),
+    REGISTRATION_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "필수 약관 동의가 필요합니다."),
     CAPACITY_FULL(HttpStatus.BAD_REQUEST, "마라톤 참가 정원이 마감되었습니다.");
 
     private final HttpStatus status;


### PR DESCRIPTION
## 📌 관련 이슈
Closes #23

## 🛠️ 작업 내용
- [x] registration 도메인 접수 생성 서비스 1차 구현
- [x] 접수 생성 시 사용자 조회, 코스 조회, 약관 동의, 접수 기간, 마라톤 상태, 정원 검증 후 저장 로직 반영
- [x] `Registration` 생성 로직 정리 및 `Course.currentCount` 증가 메서드 반영
- [x] 접수 생성에 필요한 `ErrorCode` 최소 항목 추가
- [x] `Registration.canceledAt` 제거
- [x] DB 테이블 변경 영향으로 `CancelRegistrationRes` 함께 정리

추가로, 현재는 서비스에서 `loginUserId`를 직접 전달받도록 구현되어 있으며 추후 JWT/시큐리티 연동 시 인증 정보 기반 사용자 식별로 변경할 예정입니다.  
동시성 처리는 아직 적용하지 않았습니다.

## 🎯 리뷰 포인트
- 접수 생성 서비스의 예외 처리와 `ErrorCode` 구성이 적절한지
- 누락된 예외 처리가 있는지 확인 부탁드립니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?