### PR TITLE
refactor: SecurityUser 추가하여 인증된 사용자 정보 값 수정 및 내 프로필 조회 API 추가 구현 (#38)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/users/controller/UsersController.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/controller/UsersController.java
@@ -1,0 +1,27 @@
+package com.rungo.api.domain.users.controller;
+
+import com.rungo.api.domain.users.dto.MyProfileRes;
+import com.rungo.api.domain.users.service.UsersService;
+import com.rungo.api.global.security.SecurityUser;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Tag(name = "Users", description = "사용자 컨트롤러, 사용자와 관련된 API를 제공합니다.")
+public class UsersController {
+
+    private final UsersService userService;
+
+    @GetMapping("/me")
+    public MyProfileRes getMyInfo(
+            @AuthenticationPrincipal SecurityUser user
+    ) {
+        return userService.getMyInfo(user.getId());
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/dto/MyProfileRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/dto/MyProfileRes.java
@@ -1,0 +1,16 @@
+package com.rungo.api.domain.users.dto;
+
+import com.rungo.api.domain.users.enumtype.Gender;
+import com.rungo.api.domain.users.enumtype.Role;
+
+import java.time.LocalDate;
+
+public record MyProfileRes(
+        Long id,
+        String email,
+        String name,
+        String phoneNumber,
+        Gender gender,
+        LocalDate birth,
+        Role role
+) {}

--- a/backend/src/main/java/com/rungo/api/domain/users/repository/UsersRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/repository/UsersRepository.java
@@ -1,0 +1,7 @@
+package com.rungo.api.domain.users.repository;
+
+import com.rungo.api.domain.users.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/service/UsersService.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/service/UsersService.java
@@ -1,0 +1,32 @@
+package com.rungo.api.domain.users.service;
+
+import com.rungo.api.domain.users.dto.MyProfileRes;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.repository.UsersRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UsersService {
+
+    private final UsersRepository usersRepository;
+
+    public MyProfileRes getMyInfo(Long userId) {
+
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return new MyProfileRes(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPhoneNumber(),
+                user.getGender(),
+                user.getBirth(),
+                user.getRole()
+        );
+    }
+}

--- a/backend/src/main/java/com/rungo/api/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/rungo/api/global/security/CustomAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.rungo.api.global.security;
 
+import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.global.util.JwtUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -39,14 +40,28 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 
                     if (JwtUtil.validateToken(token, jwtSecret)) {
                         Claims claims = JwtUtil.getClaims(token, jwtSecret);
-                        String username = claims.getSubject();
-                        String role = claims.get("role", String.class);
+
+                        Long id = claims.get("id", Long.class);
+                        String email = claims.get("email", String.class);
+                        String roleStr = claims.get("role", String.class);
+
+                        Role role = Role.valueOf(roleStr);
+
+                        List<SimpleGrantedAuthority> authorities =
+                                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+
+                        SecurityUser securityUser = new SecurityUser(
+                                id,
+                                email,
+                                role,
+                                authorities
+                        );
 
                         UsernamePasswordAuthenticationToken authentication =
                                 new UsernamePasswordAuthenticationToken(
-                                        username,
+                                        securityUser,
                                         null,
-                                        List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                                        authorities
                                 );
 
                         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/backend/src/main/java/com/rungo/api/global/security/SecurityUser.java
+++ b/backend/src/main/java/com/rungo/api/global/security/SecurityUser.java
@@ -1,0 +1,23 @@
+package com.rungo.api.global.security;
+
+import com.rungo.api.domain.users.enumtype.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class SecurityUser extends User { // 인증된 사용자 정보
+
+    private Long id;
+    private String email;
+    private Role role;
+
+    public SecurityUser(Long id, String email, Role role, Collection<? extends GrantedAuthority> authorities) {
+        super(email, "password", authorities); // 인증된 사용자의 password값은 필요 없으므로, 문자열 고정
+        this.id = id;
+        this.email = email;
+        this.role = role;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #38

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] SecurityUser 추가
- [x] authentication에 id 추가
- [x] 내 프로필 조회 API 구현


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 저희는 JWT 기반이라 인증된 사용자의 password 값은 필요없다고 생각하여 SecurityUser 함수에서 password 값을 문자열로 하드코딩하여 처리했습니다. 이 부분 확인 한 번 부탁드립니다!


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?