### PR TITLE
feat: 접수 생성 Controller 구현 (#32)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationCommandController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationCommandController.java
@@ -1,0 +1,35 @@
+package com.rungo.api.domain.registration.controller;
+
+import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
+import com.rungo.api.domain.registration.dto.CreateRegistrationRes;
+import com.rungo.api.domain.registration.service.RegistrationCommandService;
+import com.rungo.api.global.response.ApiResponse;
+import com.rungo.api.global.security.SecurityUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/registrations")
+public class RegistrationCommandController {
+
+    private final RegistrationCommandService registrationCommandService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateRegistrationRes>> create(
+            @AuthenticationPrincipal SecurityUser user,
+            @Valid @RequestBody CreateRegistrationReq request
+    ) {
+        CreateRegistrationRes createRegistrationRes = registrationCommandService.create(user.getId(), request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("접수가 완료되었습니다.", createRegistrationRes));
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
@@ -1,0 +1,73 @@
+package com.rungo.api.domain.registration.service;
+
+import com.rungo.api.domain.marathon.course.entity.Course;
+import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
+import com.rungo.api.domain.registration.dto.CreateRegistrationRes;
+import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.repository.RegistrationRepository;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RegistrationCommandService {
+
+    private final RegistrationRepository registrationRepository;
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+
+    public CreateRegistrationRes create(Long userId, CreateRegistrationReq request) {
+
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Course course = courseRepository.findById(request.courseId())
+                .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
+        Marathon marathon = course.getMarathon();
+        LocalDateTime now = LocalDateTime.now();
+
+        // 필수 약관 미동의
+        if (!request.agreedTerms()) {
+            throw new CustomException(ErrorCode.REGISTRATION_TERMS_REQUIRED);
+        }
+        // 접수 기간이 아니면 생성할 수 없다.
+        if (now.isBefore(marathon.getRegistrationStartAt()) || now.isAfter(marathon.getRegistrationEndAt())) {
+            throw new CustomException(ErrorCode.REGISTRATION_PERIOD_INVALID);
+        }
+        // 모집 중인 대회만 접수 가능하다.
+        if (marathon.getStatus() != MarathonStatus.OPEN) {
+            throw new CustomException(ErrorCode.MARATHON_NOT_OPEN);
+        }
+        // 코스 정원이 가득 찼으면 접수를 막는다.
+        if (course.isFull()) {
+            throw new CustomException(ErrorCode.CAPACITY_FULL);
+        }
+
+        Registration registration = Registration.create(
+                user,
+                course,
+                marathon,
+                request.snapZipCode(),
+                request.snapAddress(),
+                request.snapDetail(),
+                request.tSize(),
+                request.agreedTerms()
+        );
+
+        course.increaseCurrentCount();
+
+        Registration savedRegistration = registrationRepository.save(registration);
+
+        return CreateRegistrationRes.from(savedRegistration);
+    }
+}

--- a/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.rungo.api.global.exception;
 import com.rungo.api.global.response.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -15,6 +16,8 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final String REGISTRATION_DUPLICATE_CONSTRAINT = "uk_registration_user_marathon";
 
     // 1. 비즈니스 예외 처리 (CustomException)
     @ExceptionHandler(CustomException.class)
@@ -62,7 +65,27 @@ public class GlobalExceptionHandler {
                              .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage(), errors));
     }
 
-    // 4. 시스템 에러 처리
+    // 4. DB 유니크 제약 예외 처리
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        // registration 중복 접수 제약조건 위반은 비즈니스 예외로 변환한다.
+        if (isConstraintViolation(e, REGISTRATION_DUPLICATE_CONSTRAINT)) {
+            ErrorCode ec = ErrorCode.REGISTRATION_ALREADY_EXISTS;
+
+            log.warn("Duplicate registration detected. constraintName={}", REGISTRATION_DUPLICATE_CONSTRAINT, e);
+
+            return ResponseEntity.status(ec.getStatus())
+                    .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
+        }
+
+        // 처리 대상이 아닌 다른 DB 무결성 예외는 시스템 예외로 응답한다.
+        log.error("Unhandled DataIntegrityViolationException", e);
+        ErrorCode ec = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(ec.getStatus())
+                .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
+    }
+
+    // 5. 시스템 예외 처리
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("Internal Server Error: ", e);
@@ -70,5 +93,21 @@ public class GlobalExceptionHandler {
         ErrorCode ec = ErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity.status(ec.getStatus())
                              .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
+    }
+
+    // 예외 원인 체인을 따라가며 기대한 DB 제약조건 위반인지 확인한다.
+    private boolean isConstraintViolation(Throwable throwable, String expectedConstraintName) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            // Hibernate 예외까지 내려가 실제 제약조건명을 확인한다.
+            if (current instanceof org.hibernate.exception.ConstraintViolationException ex) {
+                String actualConstraintName = ex.getConstraintName();
+                return actualConstraintName != null && actualConstraintName.endsWith(expectedConstraintName);
+            }
+            current = current.getCause();
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #32

## 🛠️ 작업 내용
- [x] 생성 API 컨트롤러 구현 및 서비스 연동
- [x] `SecurityUser` principal 기반으로 접수 생성 로직 연결
- [x] 유니크키 충돌 시 `REGISTRATION_ALREADY_EXISTS` 예외로 변환되도록 처리
- [x] 중복 접수 요청 시 `409 Conflict` 응답 확인

## 🎯 리뷰 포인트
중복 접수 발생 시 `500`이 아닌 `409 REGISTRATION_ALREADY_EXISTS`로 응답되는 예외 처리가 괜찮은지 확인 부탁드립니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?