### PR TITLE
feat: 대회등록 controller 구현 (#29)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -9,6 +9,8 @@ import com.rungo.api.global.response.ApiResponse;
 import com.rungo.api.global.security.SecurityUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,7 +25,7 @@ public class MarathonController {
     private final MarathonService marathonService;
 
     @PostMapping
-    public ApiResponse<CreateMarathonRes> createMarathon(
+    public ResponseEntity<ApiResponse<CreateMarathonRes>> createMarathon(
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody CreateMarathonReq req
     ) {
@@ -32,6 +34,6 @@ public class MarathonController {
         }
 
         CreateMarathonRes res = marathonService.createMarathon(user.getId(), req);
-        return ApiResponse.ok(res);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("마라톤 대회 생성 성공", res));
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -1,0 +1,37 @@
+package com.rungo.api.domain.marathon.marathon.controller;
+
+import com.rungo.api.domain.marathon.marathon.dto.CreateMarathonReq;
+import com.rungo.api.domain.marathon.marathon.dto.CreateMarathonRes;
+import com.rungo.api.domain.marathon.marathon.service.MarathonService;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import com.rungo.api.global.response.ApiResponse;
+import com.rungo.api.global.security.SecurityUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/marathons")
+@RequiredArgsConstructor
+public class MarathonController {
+
+    private final MarathonService marathonService;
+
+    @PostMapping
+    public ApiResponse<CreateMarathonRes> createMarathon(
+            @AuthenticationPrincipal SecurityUser user,
+            @Valid @RequestBody CreateMarathonReq req
+    ) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        CreateMarathonRes res = marathonService.createMarathon(user.getId(), req);
+        return ApiResponse.ok(res);
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
@@ -19,6 +19,14 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "Marathon",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_marathon_organizerId_title_eventDate",
+                        columnNames = {"organizer_id","title","event_date"})
+        }
+
+)
 public class Marathon {
 
     @Id

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -8,6 +8,7 @@ import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.domain.users.repository.UserRepository;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -20,16 +21,16 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class MarathonService {
     private final MarathonRepository marathonRepository;
-
+    private final UserRepository userRepository;
     @Transactional
-    public CreateMarathonRes createMarathon(Users organizer, CreateMarathonReq req) {
+    public CreateMarathonRes createMarathon(Long id, CreateMarathonReq req) {
 
         // 주최하는 사람이 존재하는지 확인
-        if (organizer == null) {
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
-        }
+        Users organizer = userRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
         // 주최자 측 인가 확인
-        else if (organizer.getRole() != Role.ORGANIZER) {
+        if (organizer.getRole() != Role.ORGANIZER) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
@@ -78,7 +79,6 @@ public class MarathonService {
         Marathon savedMarathon = marathonRepository.save(marathon);
         return CreateMarathonRes.from(savedMarathon);
     }
-
 
     // 5k -> 5K, 10k -> 10K, " 5k " -> 5K 로 저장하기 위해 정규화하는 함수
     private String normalizeCourseType(String courseType) {

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
+    // 마라톤 대회 등록
+    MARATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 대회가 존재합니다."),
+
     // 마라톤, 접수
     MARATHON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마라톤 대회를 찾을 수 없습니다."),
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 코스를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     private static final String REGISTRATION_DUPLICATE_CONSTRAINT = "uk_registration_user_marathon";
+    private static final String MARATHON_DUPLICATE_CONSTRAINT = "uk_marathon_organizerId_title_eventDate";
 
     // 1. 비즈니스 예외 처리 (CustomException)
     @ExceptionHandler(CustomException.class)
@@ -73,6 +74,15 @@ public class GlobalExceptionHandler {
             ErrorCode ec = ErrorCode.REGISTRATION_ALREADY_EXISTS;
 
             log.warn("Duplicate registration detected. constraintName={}", REGISTRATION_DUPLICATE_CONSTRAINT, e);
+
+            return ResponseEntity.status(ec.getStatus())
+                    .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
+        }
+
+        if (isConstraintViolation(e, MARATHON_DUPLICATE_CONSTRAINT)) {
+            ErrorCode ec = ErrorCode.MARATHON_ALREADY_EXISTS;
+
+            log.warn("Duplicate marathon detected. constraintName={}", MARATHON_DUPLICATE_CONSTRAINT, e);
 
             return ResponseEntity.status(ec.getStatus())
                     .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #29 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] Service단에서 id로 User조회 하도록 Refactoring
- [x] Controller에서 user(SecurityUser)못 받아 올시 예외처리
- [x] @Valid를 통해, 필수 필드 누락시 예외처리
- [x] 조건에 맞는 요청 들어올때, db에 마라톤,코스 추가 및, 성공 응답 제출


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
지금 로직으로는, 같은 사람이 같은 대회를 연속으로 대회 등록을 하여도 해당 대회가 여러번 생성되고 있습니다.
이 사실이 문제가 된다면,
title + organizer_id 을 unique로 걸어 db단계에서 제약을 걸지, 서비스 단계에서 막을지, 아니면 2곳 다 제약을 걸지   
의견 남겨주시면 감사하겠습니다.


### marathon 데이터 샘플
| id | created\_at | event\_date | poster\_image\_url | region | registration\_end\_at | registration\_start\_at | status | title | organizer\_id |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | 2026-04-15 09:34:34.855838 | 2026-05-20 | https://example.com/poster.jpg | 서울 | 2026-04-30 18:00:00.000000 | 2026-04-01 09:00:00.000000 | OPEN | 서울 한강 마라톤 | 1 |
| 2 | 2026-04-15 11:47:41.406062 | 2026-05-20 | https://example.com/poster.jpg | 서울 | 2026-04-30 18:00:00.000000 | 2026-04-01 09:00:00.000000 | OPEN | 서울 한강 마라톤 | 1 |
| 3 | 2026-04-15 11:55:01.574339 | 2026-05-20 | https://example.com/poster.jpg | 서울 | 2026-04-30 18:00:00.000000 | 2026-04-01 09:00:00.000000 | OPEN | 서울 한강 마라톤 | 1 |
| 4 | 2026-04-15 11:57:41.790512 | 2026-05-20 | null | 서울 | 2026-04-30 18:00:00.000000 | 2026-04-01 09:00:00.000000 | OPEN | 서울 한강 마라톤 | 1 |

### 복합Unique 설정후
동호님이 만들어 주신 handleDataIntegrityViolationException 함수와 isConstraintViolation 함수가 DB Unique 제약에서 사용되는 것 같아, 저도 사용하는 방식으로 코드를 짰는데 혹시 문제 생길 것 같은지 말씀해주시면 감사하겠습니다!
## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?