### PR TITLE
feat: 접수 취소 컨트롤러 구현 (#52)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationCommandController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationCommandController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,5 +33,15 @@ public class RegistrationCommandController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("접수가 완료되었습니다.", createRegistrationRes));
+    }
+
+    @DeleteMapping("/{registrationId}")
+    public ResponseEntity<ApiResponse<Void>> cancel(
+            @AuthenticationPrincipal SecurityUser user,
+            @PathVariable Long registrationId
+    ) {
+        registrationCommandService.cancel(user.getId(), registrationId);
+
+        return ResponseEntity.ok(ApiResponse.okMessage("접수가 취소되었습니다."));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #52 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] `DELETE /api/v1/registrations/{registrationId}` 엔드포인트 구현
- [x] 인증 사용자 식별값 기준으로 서비스 호출
- [x] 존재하지 않는 신청 건 예외 처리 연결
- [x] 본인 신청이 아닌 접수 취소 예외 처리 연결
- [x] 접수 마감 후 취소 불가 예외 처리 연결


## 🎯 리뷰 포인트
- 현재 취소 API는 하드 딜리트 정책에 맞춰 `DELETE /api/v1/registrations/{registrationId}`로 구성했습니다 적절한지 확인 부탁드립니다.
- 성공 상태코드는 `200 OK`로 두었습니다. 적절한지 의견 부탁드립니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?