### PR TITLE
feat: 대회 목록 조회 API 구현 (#54)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -2,6 +2,9 @@ package com.rungo.api.domain.marathon.marathon.controller;
 
 import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonReq;
 import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonRes;
+import com.rungo.api.domain.marathon.marathon.dto.view.MarathonDetailRes;
+import com.rungo.api.domain.marathon.marathon.dto.view.MarathonListRes;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.marathon.marathon.service.MarathonService;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
@@ -9,9 +12,12 @@ import com.rungo.api.global.response.ApiResponse;
 import com.rungo.api.global.security.SecurityUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MarathonController {
 
     private final MarathonService marathonService;
+    private final MarathonRepository marathonRepository;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateMarathonRes>> createMarathon(
@@ -36,4 +43,14 @@ public class MarathonController {
         CreateMarathonRes res = marathonService.createMarathon(user.getId(), req);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("마라톤 대회 생성 성공", res));
     }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<MarathonListRes>> getMarathonList(Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(marathonService.getMarathons(pageable)));
+    }
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<MarathonDetailRes>> getMarathonDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(marathonService.getMarathonDetail(id)));
+    }
+
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/enumtype/MarathonStatus.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/enumtype/MarathonStatus.java
@@ -4,5 +4,6 @@ public enum MarathonStatus {
     TEMP,
     OPEN,
     CLOSED,
+    CANCELING,
     CANCELED
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/enumtype/MarathonStatus.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/enumtype/MarathonStatus.java
@@ -3,5 +3,6 @@ package com.rungo.api.domain.marathon.marathon.enumtype;
 public enum MarathonStatus {
     TEMP,
     OPEN,
-    CLOSED
+    CLOSED,
+    CANCELED
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
@@ -1,7 +1,13 @@
 package com.rungo.api.domain.marathon.marathon.repository;
 
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MarathonRepository extends JpaRepository<Marathon, Long> {
+    Page<Marathon> findByStatusIn(List<MarathonStatus> statuses, Pageable pageable);
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -88,6 +88,9 @@ public class MarathonService {
     public MarathonDetailRes getMarathonDetail(Long marathonId) {
         Marathon marathon = marathonRepository.findById(marathonId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+        if(marathon.getStatus() == MarathonStatus.CANCLLED) {
+            throw new CustomException(ErrorCode.MARATHON_CANCELED);
+        }
         return MarathonDetailRes.from(marathon);
     }
 

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Service
@@ -88,7 +89,7 @@ public class MarathonService {
     public MarathonDetailRes getMarathonDetail(Long marathonId) {
         Marathon marathon = marathonRepository.findById(marathonId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
-        if(marathon.getStatus() == MarathonStatus.CANCLLED) {
+        if(marathon.getStatus() == MarathonStatus.CANCELED) {
             throw new CustomException(ErrorCode.MARATHON_CANCELED);
         }
         return MarathonDetailRes.from(marathon);
@@ -96,7 +97,10 @@ public class MarathonService {
 
     @Transactional(readOnly = true)
     public MarathonListRes getMarathons(Pageable pageable) {
-        Page<Marathon> page = marathonRepository.findAll(pageable);
+        Page<Marathon> page = marathonRepository.findByStatusIn(
+                List.of(MarathonStatus.TEMP, MarathonStatus.OPEN),
+                pageable
+        );
         return MarathonListRes.from(page);
     }
     // 5k -> 5K, 10k -> 10K, " 5k " -> 5K 로 저장하기 위해 정규화하는 함수

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -3,6 +3,7 @@ package com.rungo.api.domain.marathon.marathon.service;
 import com.rungo.api.domain.marathon.course.entity.Course;
 import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonReq;
 import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonRes;
+import com.rungo.api.domain.marathon.marathon.dto.view.MarathonDetailRes;
 import com.rungo.api.domain.marathon.marathon.dto.view.MarathonListRes;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
@@ -82,6 +83,15 @@ public class MarathonService {
         Marathon savedMarathon = marathonRepository.save(marathon);
         return CreateMarathonRes.from(savedMarathon);
     }
+
+    @Transactional(readOnly = true)
+    public MarathonDetailRes getMarathonDetail(Long marathonId) {
+        Marathon marathon = marathonRepository.findById(marathonId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+        return MarathonDetailRes.from(marathon);
+    }
+
+    @Transactional(readOnly = true)
     public MarathonListRes getMarathons(Pageable pageable) {
         Page<Marathon> page = marathonRepository.findAll(pageable);
         return MarathonListRes.from(page);

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
 
     // 마라톤 대회 등록
     MARATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 대회가 존재합니다."),
-
+    MARATHON_CANCELED(HttpStatus.BAD_REQUEST, "취소된 대회입니다."),
     // 마라톤, 접수
     MARATHON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마라톤 대회를 찾을 수 없습니다."),
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 코스를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #54 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 대회 목록 조회 Service구현
- [x] 대회 단건 조회 Service 구현
- [x] 대회 목록 조회 Controller 구현
- [x] 대회 단건 조회 Controller 구현


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
조회할때, marathon의 Id가 잘못들어오는 경우는 Service쪽에 예외처리를 해놓았습니다. 혹시 다른 예외상황이 존재한다면    말씀해주신다면 감사합겠습니다!

### Status에 CANCELED 항목 추가
Status에 CANCELED 항목추가 하였고, 취소된 대회를 조회할때의 예외코드도 따로 작성하였습니다.
또한, 대회 전체를 조회할때 CANCELD(취소된 대회)와 CLOSED(종료)의 대회들은 안보이고, TEMP와OPEN 상태의 대회들만 보이도록 리팩토링 하였는데 이에 대해 의견 부탁 드립니다.

### DataBase의 Marathon테이블의 Status 변경

ALTER TABLE marathon
MODIFY status ENUM('TEMP', 'OPEN', 'CLOSED', 'CANCELING', 'CANCELED') NOT NULL;

쿼리문 작성 해주시면 감사하겠습니다! 번거롭게 해드려 정말 죄송합니다
## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?