### PR TITLE
feat: 주최측 마라톤 대회 취소 Service 구현(#67)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
@@ -3,6 +3,8 @@ package com.rungo.api.domain.marathon.marathon.entity;
 import com.rungo.api.domain.marathon.course.entity.Course;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -93,5 +95,12 @@ public class Marathon {
     public void addCourse(Course course){
         this.courses.add(course);
         course.setMarathon(this);
+    }
+
+    public void cancel(){
+        if(this.status == MarathonStatus.CANCELED || this.status == MarathonStatus.CANCELING) {
+            throw new CustomException(ErrorCode.MARATHON_ALREADY_CANCELED);
+        }
+        this.status = MarathonStatus.CANCELING;
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -105,6 +105,11 @@ public class MarathonService {
         Users organizer = findOrganizer(id);
 
         Marathon marathon = getMarathonOrThrow(marathonId);
+
+        //자기 자신이 신청한 마라톤만 취소할 수 있도록 예외 처리
+        if(marathon.getOrganizer().getId() != organizer.getId()){
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
         marathon.cancel();
         List<Registration> registrations = registrationRepository.findAllByMarathonId(marathonId);
         for(Registration registration : registrations){

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -112,13 +112,7 @@ public class MarathonService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
         marathon.cancel();
-        List<Registration> registrations =
-                registrationRepository.findAllByMarathonIdAndStatus(
-                        marathonId,
-                        RegistrationStatus.COMPLETED);
-        for(Registration registration : registrations){
-            registration.cancelByOrg();
-        }
+
         return CancelMarathonRes.from(marathon);
 
     }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -17,6 +17,7 @@ import com.rungo.api.domain.users.repository.UserRepository;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.message.LoggerNameAwareMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -35,16 +36,7 @@ public class MarathonService {
     @Transactional
     public CreateMarathonRes createMarathon(Long id, CreateMarathonReq req) {
 
-        // 주최하는 사람이 존재하는지 확인
-        Users organizer = userRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        // 주최자 측 인가 확인
-        if (organizer.getRole() != Role.ORGANIZER) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-
-
+        Users organizer = findOrganizer(id);
 
         // 대회 접수 시작일이 종료일보다 이후이면 예외 처리
         if (req.registrationStartAt().isAfter(req.registrationEndAt())) {
@@ -110,14 +102,8 @@ public class MarathonService {
 
     @Transactional
     public CancelMarathonRes cancelMarathon(Long id, Long marathonId){
-        // 주최하는 사람이 존재하는지 확인
-        Users organizer = userRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Users organizer = findOrganizer(id);
 
-        // 주최자 측 인가 확인
-        if (organizer.getRole() != Role.ORGANIZER) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
         Marathon marathon = getMarathonOrThrow(marathonId);
         marathon.cancel();
         List<Registration> registrations = registrationRepository.findAllByMarathonId(marathonId);
@@ -138,6 +124,19 @@ public class MarathonService {
     private Marathon getMarathonOrThrow(Long marathonId){
         return marathonRepository.findById(marathonId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+    }
+
+    //id로 주최자 조회 함수, 존재하지 않거나 주최자가 아니면 예외 처리
+    private Users findOrganizer(Long id){
+        // 주최하는 사람이 존재하는지 확인
+        Users organizer = userRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 주최자 측 인가 확인
+        if (organizer.getRole() != Role.ORGANIZER) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        return organizer;
     }
 
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -9,6 +9,8 @@ import com.rungo.api.domain.marathon.marathon.dto.view.MarathonListRes;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
+import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
@@ -28,6 +30,8 @@ import java.util.Set;
 public class MarathonService {
     private final MarathonRepository marathonRepository;
     private final UserRepository userRepository;
+    private final RegistrationRepository registrationRepository;
+
     @Transactional
     public CreateMarathonRes createMarathon(Long id, CreateMarathonReq req) {
 
@@ -102,6 +106,26 @@ public class MarathonService {
                 pageable
         );
         return MarathonListRes.from(page);
+    }
+
+    @Transactional
+    public CancelMarathonRes cancelMarathon(Long id, Long marathonId){
+        // 주최하는 사람이 존재하는지 확인
+        Users organizer = userRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 주최자 측 인가 확인
+        if (organizer.getRole() != Role.ORGANIZER) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        Marathon marathon = getMarathonOrThrow(marathonId);
+        marathon.cancel();
+        List<Registration> registrations = registrationRepository.findAllByMarathonId(marathonId);
+        for(Registration registration : registrations){
+            registration.cancelByOrg();
+        }
+        return CancelMarathonRes.from(marathon);
+
     }
     // 5k -> 5K, 10k -> 10K, " 5k " -> 5K 로 저장하기 위해 정규화하는 함수
     private String normalizeCourseType(String courseType) {

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -10,6 +10,7 @@ import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Role;
@@ -111,7 +112,10 @@ public class MarathonService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
         marathon.cancel();
-        List<Registration> registrations = registrationRepository.findAllByMarathonId(marathonId);
+        List<Registration> registrations =
+                registrationRepository.findAllByMarathonIdAndStatus(
+                        marathonId,
+                        RegistrationStatus.COMPLETED);
         for(Registration registration : registrations){
             registration.cancelByOrg();
         }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -3,6 +3,7 @@ package com.rungo.api.domain.marathon.marathon.service;
 import com.rungo.api.domain.marathon.course.entity.Course;
 import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonReq;
 import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonRes;
+import com.rungo.api.domain.marathon.marathon.dto.delete.CancelMarathonRes;
 import com.rungo.api.domain.marathon.marathon.dto.view.MarathonDetailRes;
 import com.rungo.api.domain.marathon.marathon.dto.view.MarathonListRes;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
@@ -87,8 +88,7 @@ public class MarathonService {
 
     @Transactional(readOnly = true)
     public MarathonDetailRes getMarathonDetail(Long marathonId) {
-        Marathon marathon = marathonRepository.findById(marathonId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+        Marathon marathon = getMarathonOrThrow(marathonId);
         if(marathon.getStatus() == MarathonStatus.CANCELED) {
             throw new CustomException(ErrorCode.MARATHON_CANCELED);
         }
@@ -109,6 +109,11 @@ public class MarathonService {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
         return courseType.trim().toUpperCase();
+    }
+
+    private Marathon getMarathonOrThrow(Long marathonId){
+        return marathonRepository.findById(marathonId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
     }
 
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
@@ -4,6 +4,8 @@ import com.rungo.api.domain.marathon.course.entity.Course;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
 import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -119,5 +121,11 @@ public class Registration {
                 tSize,
                 agreedTerms
         );
+    }
+    public void cancelByOrg(){
+        if(this.status == RegistrationStatus.CANCELED){
+            throw new CustomException(ErrorCode.REGISTRATION_ALREADY_CANCELED);
+        }
+        this.status = RegistrationStatus.CANCELED;
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
@@ -123,9 +123,7 @@ public class Registration {
         );
     }
     public void cancelByOrg(){
-        if(this.status == RegistrationStatus.CANCELED){
-            throw new CustomException(ErrorCode.REGISTRATION_ALREADY_CANCELED);
-        }
+
         this.status = RegistrationStatus.CANCELED;
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/entity/Registration.java
@@ -122,8 +122,5 @@ public class Registration {
                 agreedTerms
         );
     }
-    public void cancelByOrg(){
 
-        this.status = RegistrationStatus.CANCELED;
-    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -1,11 +1,12 @@
 package com.rungo.api.domain.registration.repository;
 
 import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     List<Registration> findAllByUser_IdOrderByAppliedAtDesc(Long userId);
-    List<Registration> findAllByMarathonId(Long marathonId);
+    List<Registration> findAllByMarathonIdAndStatus(Long marathonId, RegistrationStatus status);
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -8,5 +8,4 @@ import java.util.List;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     List<Registration> findAllByUser_IdOrderByAppliedAtDesc(Long userId);
-    List<Registration> findAllByMarathonIdAndStatus(Long marathonId, RegistrationStatus status);
-}
+    }

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     List<Registration> findAllByUser_IdOrderByAppliedAtDesc(Long userId);
+    List<Registration> findAllByMarathonId(Long marathonId);
 }

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     // 마라톤 대회 등록
     MARATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 대회가 존재합니다."),
     MARATHON_CANCELED(HttpStatus.BAD_REQUEST, "취소된 대회입니다."),
+    MARATHON_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 대회입니다."),
+
     // 마라톤, 접수
     MARATHON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마라톤 대회를 찾을 수 없습니다."),
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 코스를 찾을 수 없습니다."),
@@ -31,8 +33,8 @@ public enum ErrorCode {
     MARATHON_NOT_OPEN(HttpStatus.BAD_REQUEST, "현재 접수 가능한 대회 상태가 아닙니다."),
     REGISTRATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 접수한 대회입니다."),
     REGISTRATION_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "필수 약관 동의가 필요합니다."),
-    CAPACITY_FULL(HttpStatus.BAD_REQUEST, "마라톤 참가 정원이 마감되었습니다.");
-
+    CAPACITY_FULL(HttpStatus.BAD_REQUEST, "마라톤 참가 정원이 마감되었습니다."),
+    REGISTRATION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST,"이미 접수 취소한 대회입니다.");
     private final HttpStatus status;
     private final String message;
 }


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #67 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 마라톤 대회 취소 로직 구현
- [x] 취소하고자 하는 대회 상태가 이미 취소(CANCELED,CANCELING)인 경우 예외 처리
- [x] 주최측 인가 작업 함수화
- [x] 해당 마라톤에 접수한 사람들 찾는 함수 제작(Repository단계)
- [x] 취소한 경우, 해당 마라톤에 접수되었고,상태값 COMPLETE인 사람이 있으면 상태(CANCELED) 변경



## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
대회를 취소할때, 해당 마라톤에 접수한 참가자들의 상태를 변경만 하였습니다. 해당 방식이 적절한지 의견 부탁드립니다!
## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?