### PR TITLE
feat: 접수 현황 Service 작성 (#77)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/course/repository/CourseRepository.java
@@ -3,5 +3,8 @@ package com.rungo.api.domain.marathon.course.repository;
 import com.rungo.api.domain.marathon.course.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CourseRepository extends JpaRepository<Course, Long> {
+    List<Course> findAllByMarathon_IdOrderByIdAsc(Long marathonId);
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
@@ -7,7 +7,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MarathonRepository extends JpaRepository<Marathon, Long> {
     Page<Marathon> findByStatusIn(List<MarathonStatus> statuses, Pageable pageable);
+
+    Optional<Marathon> findByIdAndOrganizer_Id(Long marathonId, Long organizerId);
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
@@ -7,10 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface MarathonRepository extends JpaRepository<Marathon, Long> {
     Page<Marathon> findByStatusIn(List<MarathonStatus> statuses, Pageable pageable);
-
-    Optional<Marathon> findByIdAndOrganizer_Id(Long marathonId, Long organizerId);
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -1,11 +1,14 @@
 package com.rungo.api.domain.registration.repository;
 
 import com.rungo.api.domain.registration.entity.Registration;
-import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     List<Registration> findAllByUser_IdOrderByAppliedAtDesc(Long userId);
-    }
+
+    @EntityGraph(attributePaths = {"user", "course"})
+    List<Registration> findAllByMarathon_IdOrderByAppliedAtDesc(Long marathonId);
+}

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
@@ -1,7 +1,14 @@
 package com.rungo.api.domain.registration.service;
 
+import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
+import com.rungo.api.domain.registration.dto.CourseRegistrationStatusRes;
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
+import com.rungo.api.domain.registration.dto.RegistrationOverviewRes;
+import com.rungo.api.domain.registration.dto.RegistrationParticipantRes;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +20,8 @@ import java.util.List;
 public class RegistrationReadService {
 
     private final RegistrationRepository registrationRepository;
+    private final MarathonRepository marathonRepository;
+    private final CourseRepository courseRepository;
 
     @Transactional(readOnly = true)
     public List<MyRegistrationRes> getMyRegistrations(Long userId) {
@@ -22,6 +31,31 @@ public class RegistrationReadService {
                 .stream()
                 .map(MyRegistrationRes::from)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public RegistrationOverviewRes getMarathonParticipants(Long organizerId, Long marathonId) {
+
+        // 주최자의 개최한 마라톤인지 검증
+        marathonRepository.findByIdAndOrganizer_Id(marathonId, organizerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+
+        // 해당 마라톤의 접수 목록 조회 후 참가자 정보 DTO로 변환
+        List<RegistrationParticipantRes> participants = registrationRepository
+                .findAllByMarathon_IdOrderByAppliedAtDesc(marathonId)
+                .stream()
+                .map(RegistrationParticipantRes::from)
+                .toList();
+
+        // 해당 마라톤의 코스 목록 조회 후 코스별 접수 현황 DTO로 변환
+        List<CourseRegistrationStatusRes> courseStatuses = courseRepository
+                .findAllByMarathon_IdOrderByIdAsc(marathonId)
+                .stream()
+                .map(CourseRegistrationStatusRes::from)
+                .toList();
+
+        // "참가자 목록 + 코스별 접수 현황"을 하나의 응답으로 처리
+        return RegistrationOverviewRes.of(participants, courseStatuses);
     }
 
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
@@ -1,6 +1,7 @@
 package com.rungo.api.domain.registration.service;
 
 import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.registration.dto.CourseRegistrationStatusRes;
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
@@ -36,9 +37,14 @@ public class RegistrationReadService {
     @Transactional(readOnly = true)
     public RegistrationOverviewRes getMarathonParticipants(Long organizerId, Long marathonId) {
 
-        // 주최자의 개최한 마라톤인지 검증
-        marathonRepository.findByIdAndOrganizer_Id(marathonId, organizerId)
+        // 마라톤 존재 여부 검증
+        Marathon marathon = marathonRepository.findById(marathonId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+
+        // 주최자가 개최한 마라톤인지 검증
+        if (!marathon.getOrganizer().getId().equals(organizerId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         // 해당 마라톤의 접수 목록 조회 후 참가자 정보 DTO로 변환
         List<RegistrationParticipantRes> participants = registrationRepository


### PR DESCRIPTION
## 📌 관련 이슈
Closes #77 

## 🛠️ 작업 내용
- [x] `MarathonRepository` 조회 옵션 추가
- [x] `CourseRepository` 조회 옵션 추가
- [x] `RegistrationRepository` 조회 옵션 추가
- [x] 주최자의 참가자 명단 조회 Service 코드 작성


## 🎯 리뷰 포인트
- 주최자가 개최한 마라톤이 아닐 경우 `MARATHON_NOT_FOUND`를 썼는데, `FORBIDDEN`이 더 적합한지 봐주시면 감사하겠습니다.
- DTO 생성 때 설계한 것과 같이 접수자 목록과 코스별 접수 현황을 하나의 응답으로 처리하였습니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?