### PR TITLE
refactor: refreshToken 갱신 및 로그아웃 추가 구현 (#83)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/controller/AuthController.java
@@ -49,15 +49,26 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.ok(result.loginRes()));
     }
 
-    @PostMapping("/refresh")
-    @Operation(summary = "토큰 재발급", description = "토큰 재발급 API입니다. refreshToken을 가지고 accessToken을 재발급합니다.")
-    public ResponseEntity<ApiResponse<Void>> refresh(
-            @CookieValue(name = "refreshToken") String refreshToken,
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃 API입니다. 쿠키를 삭제하고 Redis의 refreshToken을 제거합니다.")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken,
             HttpServletResponse response
     ) {
-        String newAccessToken = authService.refresh(refreshToken);
+        authService.logout(refreshToken, response);
+        return ResponseEntity.ok(ApiResponse.okMessage("로그아웃되었습니다."));
+    }
 
-        CookieUtil.addCookie(response, "accessToken", newAccessToken, ACCESS_TOKEN_EXPIRE);
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "토큰 재발급 API입니다. refreshToken을 가지고 accessToken 및 refreshToken을 재발급합니다.")
+    public ResponseEntity<ApiResponse<Void>> reissue(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        TokenRes tokenRes = authService.tokenReissue(refreshToken);
+
+        CookieUtil.addCookie(response, "accessToken", tokenRes.accessToken(), ACCESS_TOKEN_EXPIRE);
+        CookieUtil.addCookie(response, "refreshToken", tokenRes.refreshToken(), REFRESH_TOKEN_EXPIRE);
 
         return ResponseEntity.ok(ApiResponse.okMessage("토큰이 재발급되었습니다."));
     }

--- a/backend/src/main/java/com/rungo/api/domain/auth/dto/TokenRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/dto/TokenRes.java
@@ -1,0 +1,8 @@
+package com.rungo.api.domain.auth.dto;
+
+public record TokenRes(
+
+        String accessToken,
+        String refreshToken
+
+) {}

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
@@ -128,11 +128,6 @@ public class AuthService {
         // Redis 조회
         String storedRefreshToken = refreshTokenService.getRefreshToken(userId);
 
-        // 저장된 refreshToken이 null일 경우
-        if (storedRefreshToken == null) {
-            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
-        }
-
         // 토큰이 불일치 할 경우에는 탈취 감지하여 Redis 삭제 후 강제 로그아웃
         if (!storedRefreshToken.equals(refreshToken)) {
             refreshTokenService.deleteRefreshToken(userId);

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
@@ -6,7 +6,9 @@ import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
+import com.rungo.api.global.util.CookieUtil;
 import com.rungo.api.global.util.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -81,8 +83,7 @@ public class AuthService {
                 jwtSecret
         );
 
-        refreshTokenService.save(user.getId(), refreshToken); // Redis에 refreshToken 저장
-        log.info("Saving refreshToken: {}", user.getId());
+        refreshTokenService.saveRefreshToken(user.getId(), refreshToken); // Redis에 refreshToken 저장
 
         LoginRes loginRes = new LoginRes(
                 user.getId(),
@@ -95,7 +96,21 @@ public class AuthService {
     }
 
     @Transactional
-    public String refresh(String refreshToken) {
+    public void logout(String refreshToken, HttpServletResponse response) {
+
+        // refreshToken이 있으면 Redis에서 삭제
+        if (refreshToken != null && JwtUtil.validateToken(refreshToken, jwtSecret)) {
+            Long userId = JwtUtil.getUserId(refreshToken, jwtSecret);
+            refreshTokenService.deleteRefreshToken(userId);
+        }
+
+        // 쿠키 삭제
+        CookieUtil.deleteCookie(response, "accessToken");
+        CookieUtil.deleteCookie(response, "refreshToken");
+    }
+
+    @Transactional
+    public TokenRes tokenReissue(String refreshToken) {
 
         // refreshToken null 체크
         if (refreshToken == null) {
@@ -113,13 +128,14 @@ public class AuthService {
         // Redis 조회
         String storedRefreshToken = refreshTokenService.getRefreshToken(userId);
 
+        // 저장된 refreshToken이 null일 경우
         if (storedRefreshToken == null) {
-            // 로그아웃 상태 or Redis 만료
             throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
-        // 토큰 불일치
+        // 토큰이 불일치 할 경우에는 탈취 감지하여 Redis 삭제 후 강제 로그아웃
         if (!storedRefreshToken.equals(refreshToken)) {
+            refreshTokenService.deleteRefreshToken(userId);
             throw new CustomException(ErrorCode.TOKEN_MISMATCH);
         }
 
@@ -127,12 +143,24 @@ public class AuthService {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // accessToken 재발급 (refreshToken은 갱신하지 않음)
-        return JwtUtil.generateAccessToken(
+        // accessToken 재발급
+        String newAccessToken = JwtUtil.generateAccessToken(
                 user.getId(),
                 user.getEmail(),
                 user.getRole(),
                 jwtSecret
         );
+
+        // refreshToken 재발급
+        String newRefreshToken = JwtUtil.generateRefreshToken(
+                user.getId(),
+                user.getEmail(),
+                jwtSecret
+        );
+
+        // Redis refreshToken 교체
+        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+
+        return new TokenRes(newAccessToken, newRefreshToken);
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/RefreshTokenService.java
@@ -2,42 +2,37 @@ package com.rungo.api.domain.auth.service;
 
 import com.rungo.api.domain.auth.entity.RefreshToken;
 import com.rungo.api.domain.auth.repository.RefreshTokenRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
-    private final RefreshTokenRepository repository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     // refreshToken 저장
-    public void save(Long userId, String refreshToken) {
+    public void saveRefreshToken(Long userId, String refreshToken) {
 
         RefreshToken token = RefreshToken.builder()
                 .userId(userId)
                 .refreshToken(refreshToken)
                 .build();
 
-        repository.save(token); // 기존 값 자동 덮어쓰기
+        refreshTokenRepository.save(token); // 기존 값 자동 덮어쓰기
     }
 
     // userId로 RefreshToken 조회
     public String getRefreshToken(Long userId) {
-
-        return findByUserId(userId).orElse(null);
+        return refreshTokenRepository.findById(userId)
+                .map(RefreshToken::getRefreshToken)
+                .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
     }
 
-    // userId로 RefreshToken 조회
-    public Optional<String> findByUserId(Long userId) {
-        return repository.findById(userId)
-                .map(RefreshToken::getRefreshToken);
-    }
-
-    // RefreshToken 삭제 (로그아웃 시)
-    public void delete(Long userId) {
-        repository.deleteById(userId);
+    // RefreshToken 삭제
+    public void deleteRefreshToken(Long userId) {
+        refreshTokenRepository.deleteById(userId);
     }
 }

--- a/backend/src/main/java/com/rungo/api/global/util/CookieUtil.java
+++ b/backend/src/main/java/com/rungo/api/global/util/CookieUtil.java
@@ -17,4 +17,12 @@ public class CookieUtil {
 
         response.addCookie(cookie);
     }
+
+    public static void deleteCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+    }
 }

--- a/backend/src/main/java/com/rungo/api/global/util/JwtUtil.java
+++ b/backend/src/main/java/com/rungo/api/global/util/JwtUtil.java
@@ -11,8 +11,8 @@ import java.util.Map;
 
 public class JwtUtil {
 
-    static int accessExpire = 60 * 60; // 1시간
-    static int refreshExpire = 60 * 60 * 24 * 7; // 7일
+    static int ACCESS_TOKEN_EXPIRE = 60 * 60; // 1시간
+    static int REFRESH_TOKEN_EXPIRE = 60 * 60 * 24 * 7; // 7일
 
      // JWT 토큰 생성
     public static String generateToken(String secret, long expireSeconds, Map<String, Object> claims) {
@@ -32,7 +32,7 @@ public class JwtUtil {
 
      // Access Token 생성 (id, email, role 포함)
     public static String generateAccessToken(Long id, String email, Role role, String secret) {
-        return generateToken(secret, accessExpire,
+        return generateToken(secret, ACCESS_TOKEN_EXPIRE,
                 Map.of(
                         "id", id,
                         "email", email,
@@ -43,7 +43,7 @@ public class JwtUtil {
 
      //  Refresh Token 생성 (id, email 포함)
     public static String generateRefreshToken(Long id, String email, String secret) {
-        return generateToken(secret, refreshExpire,
+        return generateToken(secret, REFRESH_TOKEN_EXPIRE,
                 Map.of(
                         "id", id,
                         "email", email


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #83

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] refreshToken 재발급 로직 추가 (`Refresh Token Rotation` 적용)
- [x] 로그아웃 로직 추가
- [x] 토큰 재발급 엔드포인트 변경 (`/auth/refresh` → `/auth/reissue`)을 포함한 자잘한 함수명 변경

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.

refreshToken과 관련하여 보안 강화를 위해 아래 두 가지를 추가했습니다.
1. **`Refresh Token Rotation`** 적용
재발급 시 refreshToken도 함께 교체하여 탈취된 토큰의 재사용을 방지합니다.
토큰 불일치가 감지될 경우 Redis에 저장된 refreshToken을 즉시 삭제하여 강제 로그아웃 처리합니다.

2. **로그아웃 API 추가 `(POST /auth/logout)`**
명세서에는 없지만, 로그인/재발급 로직을 구현하면서 Redis에 refreshToken을 관리하게 되어 로그아웃 시 명시적으로 토큰을 제거하는 API가 필요할 수도 있겠다고 판단하여 추가했습니다.
토큰 유무와 관계없이 쿠키를 삭제하여 클라이언트 인증 상태를 항상 초기화합니다.

- 로그아웃 API 구현이 적절한지 의견 부탁드립니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?