### PR TITLE
feat: 마라톤 수정 서비스 구현 (#85)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
@@ -63,4 +63,14 @@ public class Course {
     public Integer getRemainingCount(){
         return this.capacity - this.currentCount;
     }
+
+    public void updateCourseInfo(
+            String courseType,
+            BigDecimal price,
+            Integer capacity
+    ) {
+        if (courseType != null) this.courseType = courseType;
+        if (price != null) this.price = price;
+        if (capacity != null) this.capacity = capacity;
+    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -70,5 +70,4 @@ public class MarathonController {
         return ResponseEntity.ok(ApiResponse.ok(res));
     }
 
-
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -69,5 +69,17 @@ public class MarathonController {
         CancelMarathonRes res = marathonService.cancelMarathon(user.getId(), id);
         return ResponseEntity.ok(ApiResponse.ok(res));
     }
+    @PatchMapping("/{marathonId}")
+    public ResponseEntity<ApiResponse<UpdateMarathonRes>> update(
+            @AuthenticationPrincipal SecurityUser user,
+            @PathVariable Long marathonId,
+            @RequestBody UpdateMarathonReq req
+    ) {
+        UpdateMarathonRes res =
+                marathonService.updateMarathon(user.getId(), marathonId, req);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("마라톤 대회 수정 성공", res));
+
+    }
 
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -5,6 +5,8 @@ import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonRes;
 import com.rungo.api.domain.marathon.marathon.dto.delete.CancelMarathonRes;
 import com.rungo.api.domain.marathon.marathon.dto.read.MarathonDetailRes;
 import com.rungo.api.domain.marathon.marathon.dto.read.MarathonListRes;
+import com.rungo.api.domain.marathon.marathon.dto.update.UpdateMarathonReq;
+import com.rungo.api.domain.marathon.marathon.dto.update.UpdateMarathonRes;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.marathon.marathon.service.MarathonService;
 import com.rungo.api.global.exception.CustomException;

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -69,17 +69,6 @@ public class MarathonController {
         CancelMarathonRes res = marathonService.cancelMarathon(user.getId(), id);
         return ResponseEntity.ok(ApiResponse.ok(res));
     }
-    @PatchMapping("/{marathonId}")
-    public ResponseEntity<ApiResponse<UpdateMarathonRes>> update(
-            @AuthenticationPrincipal SecurityUser user,
-            @PathVariable Long marathonId,
-            @RequestBody UpdateMarathonReq req
-    ) {
-        UpdateMarathonRes res =
-                marathonService.updateMarathon(user.getId(), marathonId, req);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("마라톤 대회 수정 성공", res));
-
-    }
 
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
@@ -103,4 +103,21 @@ public class Marathon {
         }
         this.status = MarathonStatus.CANCELING;
     }
+
+    public void updateMarathonInfo(
+            String title,
+            String region,
+            LocalDate eventDate,
+            String posterImageUrl,
+            LocalDateTime registrationStartAt,
+            LocalDateTime registrationEndAt
+    ) {
+        if (title != null) this.title = title;
+        if (region != null) this.region = region;
+        if (eventDate != null) this.eventDate = eventDate;
+        if (posterImageUrl != null) this.posterImageUrl = posterImageUrl;
+        if (registrationStartAt != null) this.registrationStartAt = registrationStartAt;
+        if (registrationEndAt != null) this.registrationEndAt = registrationEndAt;
+    }
 }
+

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/entity/Marathon.java
@@ -91,6 +91,9 @@ public class Marathon {
     public boolean isOpen() {
         return this.status == MarathonStatus.OPEN;
     }
+    public boolean isCanceled(){
+        return (this.status == MarathonStatus.CANCELING || this.status == MarathonStatus.CANCELED);
+    }
 
     public void addCourse(Course course){
         this.courses.add(course);

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
@@ -5,9 +5,19 @@ import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MarathonRepository extends JpaRepository<Marathon, Long> {
     Page<Marathon> findByStatusIn(List<MarathonStatus> statuses, Pageable pageable);
+    @Query("""
+    SELECT DISTINCT m
+    FROM Marathon m
+    LEFT JOIN FETCH m.courses
+    WHERE m.id = :marathonId
+      AND m.organizer.id = :organizerId
+""")
+    Optional<Marathon> findByIdAndOrganizerIdWithCourses(Long marathonId, Long organizerId);
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -156,9 +156,10 @@ public class MarathonService {
         //기존에 있는 Course를 Map으로 저장
         Map<Long, Course> courseMap = toCourseMap(marathon);
 
+        validateDuplicateCourseIds(req);
         validatePatchRequest(req, marathon);
         validateDuplicateCourseType(req, marathon,courseMap);
-        validateDuplicateCourseIds(req);
+
 
         marathon.updateMarathonInfo(
                 req.title(),

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -153,8 +153,10 @@ public class MarathonService {
         if(marathon.isCanceled()){
             throw new CustomException(ErrorCode.MARATHON_ALREADY_CANCELED);
         }
+        Map<Long, Course> courseMap = toCourseMap(marathon);
+
         validatePatchRequest(req, marathon);
-        validateDuplicateCourseType(req, marathon);
+        validateDuplicateCourseType(req, marathon,courseMap);
         validateDuplicateCourseIds(req);
 
         marathon.updateMarathonInfo(
@@ -168,9 +170,8 @@ public class MarathonService {
 
         //courses 가 NUll 이 아니라면 코스 수정 로직 수행, NULL 이면 코스 수정 없이 마라톤 정보만 업데이트
         if (req.courses() != null) {
-            //기존 코스 리스트를 courseId를 key로 하는 Map으로 변환하여, 업데이트 요청에서 코스 아이디로 기존 코스 정보를 빠르게 조회할 수 있도록 함
-            Map<Long, Course> courseMap = marathon.getCourses().stream()
-                    .collect(Collectors.toMap(Course::getId, Function.identity()));
+
+
 
 
             for (UpdateMarathonReq.UpdateCourseItemReq courseReq : req.courses()) {
@@ -243,17 +244,14 @@ public class MarathonService {
     }
 
     //코스 중복 여부 검사하는 함수
-    private void validateDuplicateCourseType(UpdateMarathonReq req, Marathon marathon) {
+    private void validateDuplicateCourseType(UpdateMarathonReq req,
+                                             Marathon marathon,
+                                             Map<Long,Course> courseMap) {
 
         // 수정 요청에 코스가 없으면 검증 X
         if (req.courses() == null || req.courses().isEmpty()) {
             return;
         }
-
-        // 기존 코스를 ID기준으로 빠르게 조회하게 위해 Map변환
-        // Function.identity()는 자기자신을 반환하는 함수.
-        Map<Long, Course> courseMap = marathon.getCourses().stream()
-                .collect(Collectors.toMap(Course::getId, Function.identity()));
 
         // 기존 코스 타입 (정규화)
         Set<String> courseTypes = marathon.getCourses().stream()
@@ -298,5 +296,11 @@ public class MarathonService {
         if (distinctCount != req.courses().size()) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
+    }
+
+    //기존 코스 리스트를 courseId를 key로 하는 Map으로 변환하여, 업데이트 요청에서 코스 아이디로 기존 코스 정보를 빠르게 조회할 수 있도록 함
+    private Map<Long, Course> toCourseMap(Marathon marathon) {
+        return marathon.getCourses().stream()
+                .collect(Collectors.toMap(Course::getId, Function.identity()));
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -6,6 +6,8 @@ import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonRes;
 import com.rungo.api.domain.marathon.marathon.dto.delete.CancelMarathonRes;
 import com.rungo.api.domain.marathon.marathon.dto.read.MarathonDetailRes;
 import com.rungo.api.domain.marathon.marathon.dto.read.MarathonListRes;
+import com.rungo.api.domain.marathon.marathon.dto.update.UpdateMarathonReq;
+import com.rungo.api.domain.marathon.marathon.dto.update.UpdateMarathonRes;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
@@ -23,9 +25,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -132,6 +139,58 @@ public class MarathonService {
         return CancelMarathonRes.from(marathon);
 
     }
+
+    @Transactional
+    public UpdateMarathonRes updateMarathon(Long organizerId, Long marathonId, UpdateMarathonReq req) {
+        Marathon marathon = marathonRepository.findByIdAndOrganizerIdWithCourses(marathonId, organizerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+
+        //마라톤 접수 전까지만 수정 가능하도록 예외 처리
+        if(!LocalDateTime.now().isBefore(marathon.getRegistrationStartAt())){
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        validatePatchRequest(req, marathon);
+        validateDuplicateCourseType(req, marathon);
+        validateDuplicateCourseIds(req);
+
+        marathon.updateMarathonInfo(
+                req.title(),
+                req.region(),
+                req.eventDate(),
+                req.posterImageUrl(),
+                req.registrationStartAt(),
+                req.registrationEndAt()
+        );
+
+        //courses 가 NUll 이 아니라면 코스 수정 로직 수행, NULL 이면 코스 수정 없이 마라톤 정보만 업데이트
+        if (req.courses() != null) {
+            //기존 코스 리스트를 courseId를 key로 하는 Map으로 변환하여, 업데이트 요청에서 코스 아이디로 기존 코스 정보를 빠르게 조회할 수 있도록 함
+            Map<Long, Course> courseMap = marathon.getCourses().stream()
+                    .collect(Collectors.toMap(Course::getId, Function.identity()));
+
+
+            for (UpdateMarathonReq.UpdateCourseItemReq courseReq : req.courses()) {
+                Course course = courseMap.get(courseReq.id()); //courseReq.id()는 DTO에서 NOT Null 제약을 걸었기에 따로 Null 처리하지 않았습니다.
+
+                //수정 하고자 하는 Course 존재 안할시 예외처리
+                if (course == null) {
+                    throw new CustomException(ErrorCode.COURSE_NOT_FOUND);
+                }
+
+                course.updateCourseInfo(
+                        courseReq.courseType(),
+                        courseReq.price(),
+                        courseReq.capacity()
+                );
+            }
+        }
+
+        return UpdateMarathonRes.from(marathon);
+    }
+
+
+
     // 5k -> 5K, 10k -> 10K, " 5k " -> 5K 로 저장하기 위해 정규화하는 함수
     private String normalizeCourseType(String courseType) {
         if (courseType == null) {
@@ -157,5 +216,84 @@ public class MarathonService {
         }
         return organizer;
     }
+    // 들어온 날짜를 토대로 유효성 검증하는 함수, null이 들어온 경우 기존 마라톤 정보를 토대로 검증
+    private void validatePatchRequest(UpdateMarathonReq req, Marathon marathon) {
+        LocalDateTime registrationStartAt = req.registrationStartAt() != null
+                ? req.registrationStartAt()
+                : marathon.getRegistrationStartAt();
 
+        LocalDateTime registrationEndAt = req.registrationEndAt() != null
+                ? req.registrationEndAt()
+                : marathon.getRegistrationEndAt();
+
+        LocalDate eventDate = req.eventDate() != null
+                ? req.eventDate()
+                : marathon.getEventDate();
+
+        if (registrationStartAt.isAfter(registrationEndAt)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        if (eventDate.isBefore(registrationEndAt.toLocalDate())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    //코스 중복 여부 검사하는 함수
+    private void validateDuplicateCourseType(UpdateMarathonReq req, Marathon marathon) {
+
+        // 수정 요청에 코스가 없으면 검증 X
+        if (req.courses() == null || req.courses().isEmpty()) {
+            return;
+        }
+
+        // 기존 코스를 ID기준으로 빠르게 조회하게 위해 Map변환
+        // Function.identity()는 자기자신을 반환하는 함수.
+        Map<Long, Course> courseMap = marathon.getCourses().stream()
+                .collect(Collectors.toMap(Course::getId, Function.identity()));
+
+        // 기존 코스 타입 (정규화)
+        Set<String> courseTypes = marathon.getCourses().stream()
+                .map(course -> normalizeCourseType(course.getCourseType()))
+                .collect(Collectors.toSet());
+
+        for (UpdateMarathonReq.UpdateCourseItemReq courseReq : req.courses()) {
+
+            // 타입 변경 없는 경우는 제외
+            if (courseReq.courseType() == null) continue;
+
+            Course target = courseMap.get(courseReq.id());
+            if (target == null) {
+                throw new CustomException(ErrorCode.COURSE_NOT_FOUND);
+            }
+
+            String originalType = normalizeCourseType(target.getCourseType());
+            String newType = normalizeCourseType(courseReq.courseType());
+
+            // 기존 값 제거
+            courseTypes.remove(originalType);
+
+            // 새 값 넣어보고 중복 검사
+            if (!courseTypes.add(newType)) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+
+        }
+    }
+
+    //코스 아이디 중복 여부 검사하는 함수.
+    private void validateDuplicateCourseIds(UpdateMarathonReq req) {
+        if (req.courses() == null || req.courses().isEmpty()) {
+            return;
+        }
+
+        long distinctCount = req.courses().stream()
+                .map(UpdateMarathonReq.UpdateCourseItemReq::id)
+                .distinct()
+                .count();
+
+        if (distinctCount != req.courses().size()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -153,6 +153,7 @@ public class MarathonService {
         if(marathon.isCanceled()){
             throw new CustomException(ErrorCode.MARATHON_ALREADY_CANCELED);
         }
+        //기존에 있는 Course를 Map으로 저장
         Map<Long, Course> courseMap = toCourseMap(marathon);
 
         validatePatchRequest(req, marathon);
@@ -253,32 +254,41 @@ public class MarathonService {
             return;
         }
 
-        // 기존 코스 타입 (정규화)
-        Set<String> courseTypes = marathon.getCourses().stream()
-                .map(course -> normalizeCourseType(course.getCourseType()))
-                .collect(Collectors.toSet());
+        // 먼저 기존 Course를 중복허용 하는 Map으로 저장.
+        Map<Long, String> finalCourseTypes = marathon.getCourses().stream()
 
+                .collect(Collectors.toMap(
+                        Course::getId,
+                        course -> normalizeCourseType(course.getCourseType())
+                ));
+
+        //수정 사항 반영.
         for (UpdateMarathonReq.UpdateCourseItemReq courseReq : req.courses()) {
 
-            // 타입 변경 없는 경우는 제외
-            if (courseReq.courseType() == null) continue;
-
             Course target = courseMap.get(courseReq.id());
+
+            //만약 수정하려는 Course가 DB에 존재하지 않는다면 예외 처리
             if (target == null) {
                 throw new CustomException(ErrorCode.COURSE_NOT_FOUND);
             }
 
-            String originalType = normalizeCourseType(target.getCourseType());
-            String newType = normalizeCourseType(courseReq.courseType());
+            //null들어오면 수정 X
+            if (courseReq.courseType() == null) continue;
 
-            // 기존 값 제거
-            courseTypes.remove(originalType);
+            //중복을 허용하며, Map에 일단 저장
+            finalCourseTypes.put(
+                    courseReq.id(),
+                    normalizeCourseType(courseReq.courseType())
+            );
+        }
 
-            // 새 값 넣어보고 중복 검사
-            if (!courseTypes.add(newType)) {
-                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-            }
+        //Set에 기존에 만들었던 Map의 Value를 저장.
+        // 이때 중복이 생긴다면, Set의 사이즈와 Map의 사이즈가 달라지는 것을 이용
+        Set<String> uniqueTypes = new HashSet<>(finalCourseTypes.values());
 
+        if (uniqueTypes.size() != finalCourseTypes.size()) {
+
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
 

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -150,6 +150,9 @@ public class MarathonService {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
+        if(marathon.isCanceled()){
+            throw new CustomException(ErrorCode.MARATHON_ALREADY_CANCELED);
+        }
         validatePatchRequest(req, marathon);
         validateDuplicateCourseType(req, marathon);
         validateDuplicateCourseIds(req);


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #85 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
마라톤 대회와 코스 수정 서비스 구현
- [x] 수정 시, 필드 값 변환이 이뤄지므로 Entity에서 Update 함수 제작
- [x] 수정 시 코스 정보가 필요 하므로, 속도 향상을 위해 마라톤 조회 시 fetch join을 이용한 메서드 Repository에 추가
- [x] 가독성을 위하여, 들어온 날짜 검증함수, 코스 아이디 중복 여부 검증함수, 코스 타입 중복여부 검증함수 구현
- [x] 마라톤 수정 Service 구현


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
- 코스 수정시, 같은 코스의 타입을 기존 타입으로 변경시 가능해야 할것 같다고 판단하였습니다. 이에 따라 두가지 방안을 고민하였습니다. 기본적으로 중복 검사는 Set을 이용하여 검사하는데, 기존 타입을 삭제하고 수정요청 들어온 타입을 넣는 방식으로 구현하였습니다. 
- https://www.notion.so/26-04-17_-_2-34515a01205480839128f09c7413795c?source=copy_link
- 이 부분은 노션에 따로 문서화 하였습니다

추가 수정
현재 마라톤의 상태가 Canceled,Canceling 인 마라톤은 수정 불가능하게 만들었습니다.
현재 Course를 Map으로 저장하는 로직은 updateMarathon메서드에서 중복 사용되므로 함수화 하였습니다.
코스타입의 Swap문제를 고려하지 못해, 코스 중복 확인 함수의 로직을 변경하였습니다
## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?