### PR TITLE
fix: 접수 정원 동시성 제어 적용 (#86)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/course/repository/CourseRepository.java
@@ -2,9 +2,30 @@ package com.rungo.api.domain.marathon.course.repository;
 
 import com.rungo.api.domain.marathon.course.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
     List<Course> findAllByMarathon_IdOrderByIdAsc(Long marathonId);
+
+    @Modifying
+    @Query("""
+            update Course c
+            set c.currentCount = c.currentCount + 1
+            where c.id = :courseId
+              and c.currentCount < c.capacity
+            """)
+    int increaseCurrentCountIfNotFull(@Param("courseId") Long courseId);
+
+    @Modifying
+    @Query("""
+            update Course c
+            set c.currentCount = c.currentCount - 1
+            where c.id = :courseId
+              and c.currentCount > 0
+            """)
+    int decreaseCurrentCountIfPositive(@Param("courseId") Long courseId);
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
@@ -104,10 +104,7 @@ public class RegistrationCommandService {
             throw new CustomException(ErrorCode.MARATHON_NOT_OPEN);
         }
 
-        int updatedRows = courseRepository.decreaseCurrentCountIfPositive(registration.getCourse().getId());
-        if (updatedRows == 0) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
+        courseRepository.decreaseCurrentCountIfPositive(registration.getCourse().getId());
         // 동시성 제어 미적용 메서드
         // registration.getCourse().decreaseCurrentCount();
         registrationRepository.delete(registration);

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
@@ -50,10 +50,6 @@ public class RegistrationCommandService {
         if (!marathon.isOpen()) {
             throw new CustomException(ErrorCode.MARATHON_NOT_OPEN);
         }
-        // 코스 정원이 가득 찼으면 접수를 막는다.
-        if (course.isFull()) {
-            throw new CustomException(ErrorCode.CAPACITY_FULL);
-        }
 
         Registration registration = Registration.create(
                 user,
@@ -66,8 +62,13 @@ public class RegistrationCommandService {
                 request.agreedTerms()
         );
 
-        course.increaseCurrentCount();
-
+        int updatedRows = courseRepository.increaseCurrentCountIfNotFull(course.getId());
+        // 코스 정원이 가득 찼으면 접수를 막는다.
+        if (updatedRows == 0) {
+            throw new CustomException(ErrorCode.CAPACITY_FULL);
+        }
+        // 동시성 제어 미적용 메서드
+        // course.increaseCurrentCount();
         Registration savedRegistration = registrationRepository.save(registration);
 
         eventPublisher.publishEvent(
@@ -103,7 +104,12 @@ public class RegistrationCommandService {
             throw new CustomException(ErrorCode.MARATHON_NOT_OPEN);
         }
 
-        registration.getCourse().decreaseCurrentCount();
+        int updatedRows = courseRepository.decreaseCurrentCountIfPositive(registration.getCourse().getId());
+        if (updatedRows == 0) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        // 동시성 제어 미적용 메서드
+        // registration.getCourse().decreaseCurrentCount();
         registrationRepository.delete(registration);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #86

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] `CourseRepository`에 정원 조건 기반 원자적 증가/감소 쿼리 추가
- [x] 접수 생성 시 `currentCount` 증가를 엔티티 변경 방식에서 원자적 업데이트 방식으로 변경
- [x] 접수 취소 시 `currentCount` 감소를 원자적 업데이트 방식으로 변경
- [x] 기존 엔티티 메서드 기반 증감 로직은 주석으로 남겨 비교 가능하게 정리


## 🎯 리뷰 포인트
- 접수 생성은 `increaseCurrentCountIfNotFull()` 결과로 정원 마감 여부를 판정하도록 변경했습니다.
- 접수 취소는 현재 `currentCount`가 0인데 취소 요청이 들어오는 경우를 DB 정합성 이상 상황으로 보고 `INTERNAL_SERVER_ERROR`를 반환하도록 처리했습니다. 이 방향이 적절한지 확인 부탁드립니다.
- 실제 동시 요청 상황에 대한 테스트는 추후 진행 예정입니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?