### PR TITLE
feat: 접수 현황 조회 Controller 작성 (#91)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationsReadController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationsReadController.java
@@ -1,12 +1,14 @@
 package com.rungo.api.domain.registration.controller;
 
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
+import com.rungo.api.domain.registration.dto.RegistrationOverviewRes;
 import com.rungo.api.domain.registration.service.RegistrationReadService;
 import com.rungo.api.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -23,6 +25,18 @@ public class RegistrationsReadController {
     public ResponseEntity<ApiResponse<List<MyRegistrationRes>>> getMyRegistrations(@AuthenticationPrincipal(expression = "id") Long userId) {
 
         List<MyRegistrationRes> result = registrationReadService.getMyRegistrations(userId);
+
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    // 주최자 - 접수 현황 조회
+    @GetMapping("/api/v1/organizer/marathons/{id}/registrations")
+    public ResponseEntity<ApiResponse<RegistrationOverviewRes>> getMarathonParticipants(
+            @AuthenticationPrincipal(expression = "id") Long organizerId,
+            @PathVariable("id") Long marathonId
+    ) {
+
+        RegistrationOverviewRes result = registrationReadService.getMarathonParticipants(organizerId, marathonId);
 
         return ResponseEntity.ok(ApiResponse.ok(result));
     }

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
+    @EntityGraph(attributePaths = {"marathon", "course"})
     List<Registration> findAllByUser_IdOrderByAppliedAtDesc(Long userId);
 
     @EntityGraph(attributePaths = {"user", "course"})


### PR DESCRIPTION
## 📌 관련 이슈
Closes #91

## 🛠️ 작업 내용
- [x] 기존 내 접수 조회에서 N+1 이슈 발생 가능하므로 기존 `RegistrationRepository`의 JPA 메서드에도 `@EntityGraph` 추가
- [x] 접수 현황 조회 Controller 작성

## 🎯 리뷰 포인트
- 코스별 접수 현황과 참가자 목록을 하나의 응답으로 보내줍니다.
- 추가로, 다른 분들처럼 `@EntityGraph` 대신 `@Query`으로 통일해서 사용하는 게 나을지 궁금합니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?