### PR TITLE
feat: update marathon controller (#92)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -73,7 +73,7 @@ public class MarathonController {
     public ResponseEntity<ApiResponse<UpdateMarathonRes>> update(
             @AuthenticationPrincipal SecurityUser user,
             @PathVariable Long marathonId,
-            @RequestBody UpdateMarathonReq req
+            @Valid @RequestBody UpdateMarathonReq req
     ) {
         UpdateMarathonRes res =
                 marathonService.updateMarathon(user.getId(), marathonId, req);

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -69,5 +69,17 @@ public class MarathonController {
         CancelMarathonRes res = marathonService.cancelMarathon(user.getId(), id);
         return ResponseEntity.ok(ApiResponse.ok(res));
     }
+    @PatchMapping("/{marathonId}")
+    public ResponseEntity<ApiResponse<UpdateMarathonRes>> update(
+            @AuthenticationPrincipal SecurityUser user,
+            @PathVariable Long marathonId,
+            @RequestBody UpdateMarathonReq req
+    ) {
+        UpdateMarathonRes res =
+                marathonService.updateMarathon(user.getId(), marathonId, req);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created("마라톤 대회 수정 성공", res));
+
+    }
 
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
@@ -4,6 +4,7 @@ import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,12 +13,7 @@ import java.util.Optional;
 
 public interface MarathonRepository extends JpaRepository<Marathon, Long> {
     Page<Marathon> findByStatusIn(List<MarathonStatus> statuses, Pageable pageable);
-    @Query("""
-    SELECT DISTINCT m
-    FROM Marathon m
-    LEFT JOIN FETCH m.courses
-    WHERE m.id = :marathonId
-      AND m.organizer.id = :organizerId
-""")
+
+    @EntityGraph(attributePaths = {"courses"})
     Optional<Marathon> findByIdAndOrganizerIdWithCourses(Long marathonId, Long organizerId);
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/repository/MarathonRepository.java
@@ -14,6 +14,6 @@ import java.util.Optional;
 public interface MarathonRepository extends JpaRepository<Marathon, Long> {
     Page<Marathon> findByStatusIn(List<MarathonStatus> statuses, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"courses"})
-    Optional<Marathon> findByIdAndOrganizerIdWithCourses(Long marathonId, Long organizerId);
+    @EntityGraph(attributePaths = "courses")
+    Optional<Marathon> findByIdAndOrganizer_Id(Long marathonId, Long organizerId);
 }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -142,7 +142,7 @@ public class MarathonService {
 
     @Transactional
     public UpdateMarathonRes updateMarathon(Long organizerId, Long marathonId, UpdateMarathonReq req) {
-        Marathon marathon = marathonRepository.findByIdAndOrganizerIdWithCourses(marathonId, organizerId)
+        Marathon marathon = marathonRepository.findByIdAndOrganizer_Id(marathonId, organizerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
 
         //마라톤 접수 전까지만 수정 가능하도록 예외 처리


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #92 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 마라톤 수정용 Controller 제작
- [ ] MarathonId와 주최자Id로 마라톤 찾아오는 로직으로 EntityGraph 사용


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
먼저,  처음에는 연관 엔티티 조회 시 중복 row 증가룰 제어하기 위해 Distinct를 붙여 JPQL을 사용했습니다.
이후 찾아보니 해당 로직이 단건 조회라는 점에서 성능차이가 미미하다는 것을 발견하였습니다
따라서, 가독성과 유지보수성을 높이기 위해 EntityGraph로 변경했습니다. 이 부분 괜찮을지 의견 남겨주시면 감사하겠습니다!

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?