### PR TITLE
chore: 커스텀 인증 필터 테스트 (#89)

### DIFF
--- a/backend/src/test/java/com/rungo/api/global/security/CustomAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/rungo/api/global/security/CustomAuthenticationFilterTest.java
@@ -1,0 +1,117 @@
+package com.rungo.api.global.security;
+
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.global.config.SecurityConfig;
+import com.rungo.api.global.security.support.TestSecurityController;
+import com.rungo.api.global.util.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TestSecurityController.class)
+@Import({SecurityConfig.class, CustomAuthenticationFilter.class})
+@TestPropertySource(properties = "jwt.secret=itistestsecretkeyforjwtabcdefghijklmnopqrstuvwxyz") // 필터가 사용
+class CustomAuthenticationFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static final String JWT_SECRET_KEY = "itistestsecretkeyforjwtabcdefghijklmnopqrstuvwxyz"; // 토큰 만들 때 사용
+    private static final String COOKIE_NAME = "accessToken";
+
+    private String validToken(Long id, String email, Role role) {
+        return JwtUtil.generateToken(JWT_SECRET_KEY, 3600,
+                Map.of("id", id, "email", email, "role", role.name()));
+    }
+
+    private String expiredToken(Long id, String email, Role role) {
+        return JwtUtil.generateToken(JWT_SECRET_KEY, -1,
+                Map.of("id", id, "email", email, "role", role.name()));
+    }
+
+    @Test
+    @DisplayName("유효한 accessToken 쿠키가 있으면 id, email, role을 정상 파싱한다.")
+    void validToken_parsesClaimsCorrectly() throws Exception {
+        String token = validToken(1L, "user@test.com", Role.PARTICIPANT);
+
+        mockMvc.perform(get("/test/me")
+                        .cookie(new Cookie(COOKIE_NAME, token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.email").value("user@test.com"))
+                .andExpect(jsonPath("$.role").value("PARTICIPANT"));
+    }
+
+    @Test
+    @DisplayName("파싱된 클레임으로 SecurityUser가 올바르게 생성되는지 검증한다.")
+    void validToken_createsSecurityUserCorrectly() throws Exception {
+        String token = validToken(42L, "organizer@test.com", Role.ORGANIZER);
+
+        mockMvc.perform(get("/test/me")
+                        .cookie(new Cookie(COOKIE_NAME, token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(42))
+                .andExpect(jsonPath("$.email").value("organizer@test.com"))
+                .andExpect(jsonPath("$.role").value("ORGANIZER"));
+    }
+
+    @Test
+    @DisplayName("SecurityContext에 Authentication이 저장됐는지 검증한다. 저장이 안 됐다면 null이 되어 401을 반환한다.")
+    void validToken_setsAuthenticationInSecurityContext() throws Exception {
+        String token = validToken(1L, "user@test.com", Role.PARTICIPANT);
+
+        mockMvc.perform(get("/test/me")
+                        .cookie(new Cookie(COOKIE_NAME, token)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("만료된 토큰으로 요청했을 때 SecurityContext에 인증 정보를 저장하지 않는다.")
+    void expiredToken_doesNotSetAuthentication() throws Exception {
+        String token = expiredToken(1L, "user@test.com", Role.PARTICIPANT);
+
+        mockMvc.perform(get("/test/me")
+                        .cookie(new Cookie(COOKIE_NAME, token)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("서명이 변조된 토큰으로 요청했을 때 인증 정보가 저장되지 않는다.")
+    void tamperedToken_doesNotSetAuthentication() throws Exception {
+        String token = validToken(1L, "user@test.com", Role.PARTICIPANT) + "tampered";
+
+        mockMvc.perform(get("/test/me")
+                        .cookie(new Cookie(COOKIE_NAME, token)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("쿠키 자체가 존재하지 않을 때 인증 정보가 저장되지 않는다.")
+    void noCookie_doesNotSetAuthentication() throws Exception {
+        mockMvc.perform(get("/test/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("role 값이 ROLE_ 접두사를 붙여 GrantedAuthority로 매핑된다.")
+    void role_mappedToGrantedAuthority() throws Exception {
+
+        String token = validToken(1L, "admin@test.com", Role.ADMIN);
+
+        mockMvc.perform(get("/test/me")
+                        .cookie(new Cookie(COOKIE_NAME, token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("ADMIN"));
+    }
+}

--- a/backend/src/test/java/com/rungo/api/global/security/support/TestSecurityController.java
+++ b/backend/src/test/java/com/rungo/api/global/security/support/TestSecurityController.java
@@ -1,0 +1,28 @@
+package com.rungo.api.global.security.support;
+
+import com.rungo.api.global.security.SecurityUser;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/test")
+public class TestSecurityController {
+
+    @GetMapping("/me")
+    public ResponseEntity<?> me(@AuthenticationPrincipal SecurityUser securityUser) {
+        if (securityUser == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        return ResponseEntity.ok(Map.of(
+                "id", securityUser.getId(),
+                "email", securityUser.getEmail(),
+                "role", securityUser.getRole().name()
+        ));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #89

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] JWT 클레임(id, email, role) 파싱 검증
- [x] JWT 클레임(id, email, role) 파싱 검증
- [x] SecurityContext에 Authentication 저장 여부 검증
- [x] 예외 케이스 테스트 추가
- [x] role → ROLE_* 권한 매핑 검증


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.

커스텀 인증 필터 테스트는 비즈니스 로직이 아닌 인증 필터의 동작을 검증하는 데 목적이 있기 때문에, 실제 엔드포인트 대신 `/test/me`를 사용했습니다.

실제 엔드포인트를 사용할 경우 `Controller`, `Service`, `Repository` 등 불필요한 의존성이 함께 포함되어 테스트 범위가 넓어지고, 결과적으로 필터가 아닌 전체 서비스 통합 테스트의 성격을 띠게 됩니다.

테스트 실패 시 원인이 필터인지, 서비스 로직인지, 혹은 데이터 계층 문제인지 구분하기 어려워지기 때문에,
인증 흐름만을 명확하게 검증할 수 있도록 별도의 테스트용 엔드포인트를 구성했습니다.

따라서, 컨트롤러(/test/me)를 활용한 간접적인 SecurityContext 검증 방식이 적절한지 검토 부탁드립니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?