### PR TITLE
test: 참가 신청 기반 비동기 알림 통합 테스트 (#93)

### DIFF
--- a/backend/src/test/java/com/rungo/api/domain/notification/listener/NotificationIntegrationTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/notification/listener/NotificationIntegrationTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 @SpringBootTest
 public class NotificationIntegrationTest {
@@ -43,4 +44,22 @@ public class NotificationIntegrationTest {
                 .sendEmail(eq("test@test.com"), anyString(), anyString());
     }
 
+    @Test
+    @Transactional
+    @DisplayName("트랜잭션이 롤백되면 이벤트가 발행되어도 이메일은 발송되지 않는다")
+    void rollback_event_listener_test() throws InterruptedException {
+        RegistrationCompletedEvent event =
+                new RegistrationCompletedEvent("rollback@test.com", "롤백 마라톤", "10km");
+
+        eventPublisher.publishEvent(event);
+
+        TestTransaction.flagForRollback();
+        TestTransaction.end();
+
+        Thread.sleep(1000);
+
+        // 한 번도 호출되지 않았음을 검증
+        verify(emailService, never())
+                .sendEmail(anyString(), anyString(), anyString());
+    }
 }

--- a/backend/src/test/java/com/rungo/api/domain/notification/listener/NotificationIntegrationTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/notification/listener/NotificationIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.rungo.api.domain.notification.listener;
+
+import com.rungo.api.domain.notification.event.RegistrationCompletedEvent;
+import com.rungo.api.global.infrastructure.mail.EmailService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.transaction.TestTransaction; // 💡 임포트 추가!
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+public class NotificationIntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @Test
+    @Transactional
+    @DisplayName("트랜잭션 안에서 이벤트가 발행되면, 커밋 후 비동기로 이메일 발송이 호출된다")
+    void async_event_listener_integration_test() {
+        RegistrationCompletedEvent event = new RegistrationCompletedEvent("test@test.com", "통합테스트 마라톤", "10km");
+
+        // 트랜잭션 내에서 이벤트 발행 (롤백 대기 상태)
+        eventPublisher.publishEvent(event);
+
+        // 테스트 트랜잭션 강제 커밋 후 종료 -> 리스너 작동
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // 커밋 완료, 비동기 스레드에서 메일 발송이 일어났는지 최대 2초 기다리며 검증
+        verify(emailService, timeout(2000).times(1))
+                .sendEmail(eq("test@test.com"), anyString(), anyString());
+    }
+
+}

--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -62,7 +63,6 @@ class RegistrationCommandServiceIntegrationTest {
     @Test
     @DisplayName("이메일 발송 실패가 발생해도 참가 접수 데이터는 정상 저장된다")
     void email_exception_isolation_test() {
-        // given
         doThrow(new RuntimeException("SMTP 서버 강제 다운"))
                 .when(emailService).sendEmail(anyString(), anyString(), anyString());
 
@@ -136,4 +136,79 @@ class RegistrationCommandServiceIntegrationTest {
         verify(emailService, timeout(2000).atLeastOnce())
                 .sendEmail(anyString(), anyString(), anyString());
     }
+
+    @Test
+    @DisplayName("참가 접수 성공 시 이메일이 비동기로 발송되고 접수 데이터가 저장된다")
+    void registration_success_email_send_test() {
+        Users organizer = userRepository.save(
+                Users.builder()
+                     .email("organizer-success@test.com")
+                     .password("1234")
+                     .name("주최자")
+                     .phoneNumber("010-1111-1111")
+                     .role(Role.ORGANIZER)
+                     .gender(Gender.MALE)
+                     .birth(LocalDate.of(1990, 1, 1))
+                     .build()
+        );
+
+        Users participant = userRepository.save(
+                Users.builder()
+                     .email("participant-success@test.com")
+                     .password("1234")
+                     .name("참가자")
+                     .phoneNumber("010-2222-2222")
+                     .role(Role.PARTICIPANT)
+                     .gender(Gender.MALE)
+                     .birth(LocalDate.of(2000, 1, 1))
+                     .build()
+        );
+
+        Marathon marathon = new Marathon(
+                organizer,
+                "서울 마라톤",
+                "서울",
+                LocalDate.now().plusDays(10),
+                "poster.png",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(5),
+                MarathonStatus.OPEN
+        );
+
+        Course course = new Course(
+                "10K",
+                BigDecimal.valueOf(30000),
+                100,
+                0
+        );
+
+        marathon.addCourse(course);
+        marathonRepository.save(marathon);
+
+        CreateRegistrationReq req = new CreateRegistrationReq(
+                course.getId(),
+                "12345",
+                "서울시 강남구",
+                "101동",
+                "L",
+                true
+        );
+
+        CreateRegistrationRes res = registrationCommandService.create(participant.getId(), req);
+
+        assertThat(res).isNotNull();
+        assertThat(res.registrationId()).isNotNull();
+        assertThat(registrationRepository.findById(res.registrationId())).isPresent();
+
+        Course savedCourse = courseRepository.findById(course.getId()).orElseThrow();
+        assertThat(savedCourse.getCurrentCount()).isEqualTo(1);
+
+        verify(emailService, timeout(2000).times(1))
+                .sendEmail(
+                        eq("participant-success@test.com"),
+                        anyString(),
+                        anyString()
+                );
+    }
+
 }

--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
@@ -1,0 +1,139 @@
+package com.rungo.api.domain.registration.service;
+
+import com.rungo.api.domain.marathon.course.entity.Course;
+import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
+import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
+import com.rungo.api.domain.registration.dto.CreateRegistrationRes;
+import com.rungo.api.domain.registration.repository.RegistrationRepository;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Gender;
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.infrastructure.mail.EmailService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class RegistrationCommandServiceIntegrationTest {
+
+    @Autowired
+    private RegistrationCommandService registrationCommandService;
+
+    @Autowired
+    private RegistrationRepository registrationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MarathonRepository marathonRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @AfterEach
+    void tearDown() {
+        registrationRepository.deleteAllInBatch();
+        courseRepository.deleteAllInBatch();
+        marathonRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("이메일 발송 실패가 발생해도 참가 접수 데이터는 정상 저장된다")
+    void email_exception_isolation_test() {
+        // given
+        doThrow(new RuntimeException("SMTP 서버 강제 다운"))
+                .when(emailService).sendEmail(anyString(), anyString(), anyString());
+
+        Users organizer = userRepository.save(
+                Users.builder()
+                     .email("organizer@test.com")
+                     .password("1234")
+                     .name("주최자")
+                     .phoneNumber("010-1111-1111")
+                     .role(Role.ORGANIZER)
+                     .gender(Gender.MALE)
+                     .birth(LocalDate.of(1990, 1, 1))
+                     .build()
+        );
+
+        Users participant = userRepository.save(
+                Users.builder()
+                     .email("participant@test.com")
+                     .password("1234")
+                     .name("참가자")
+                     .phoneNumber("010-2222-2222")
+                     .role(Role.PARTICIPANT)
+                     .gender(Gender.MALE)
+                     .birth(LocalDate.of(2000, 1, 1))
+                     .build()
+        );
+
+        Marathon marathon = new Marathon(
+                organizer,
+                "서울 마라톤",
+                "서울",
+                LocalDate.now().plusDays(10),
+                "poster.png",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(5),
+                MarathonStatus.OPEN
+        );
+
+        Course course = new Course(
+                "10K",
+                BigDecimal.valueOf(30000),
+                100,
+                0
+        );
+
+        marathon.addCourse(course);
+        marathonRepository.save(marathon); // cascade로 course까지 자동 저장
+
+        CreateRegistrationReq req = new CreateRegistrationReq(
+                course.getId(),
+                "12345",
+                "서울시 강남구",
+                "101동",
+                "L",
+                true
+        );
+
+        CreateRegistrationRes res = registrationCommandService.create(participant.getId(), req);
+
+        assertThat(res).isNotNull();
+        assertThat(res.registrationId()).isNotNull();
+
+        // 실제 DB에 데이터가 저장(Commit)되었는지 검증
+        assertThat(registrationRepository.findById(res.registrationId())).isPresent();
+
+        // 정원이 정상적으로 1명 늘었는지 검증
+        Course savedCourse = courseRepository.findById(course.getId()).orElseThrow();
+        assertThat(savedCourse.getCurrentCount()).isEqualTo(1);
+
+        // 에러가 발생해도 이메일 발송 시도는 이루어졌는지 검증
+        verify(emailService, timeout(2000).atLeastOnce())
+                .sendEmail(anyString(), anyString(), anyString());
+    }
+}

--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
@@ -66,83 +66,51 @@ class RegistrationCommandServiceIntegrationTest {
         doThrow(new RuntimeException("SMTP 서버 강제 다운"))
                 .when(emailService).sendEmail(anyString(), anyString(), anyString());
 
-        Users organizer = userRepository.save(
-                Users.builder()
-                     .email("organizer@test.com")
-                     .password("1234")
-                     .name("주최자")
-                     .phoneNumber("010-1111-1111")
-                     .role(Role.ORGANIZER)
-                     .gender(Gender.MALE)
-                     .birth(LocalDate.of(1990, 1, 1))
-                     .build()
-        );
+        Users organizer = saveOrganizer("organizer@test.com");
+        Users participant = saveParticipant("participant@test.com");
+        Course course = saveCourseWithMarathon(organizer);
 
-        Users participant = userRepository.save(
-                Users.builder()
-                     .email("participant@test.com")
-                     .password("1234")
-                     .name("참가자")
-                     .phoneNumber("010-2222-2222")
-                     .role(Role.PARTICIPANT)
-                     .gender(Gender.MALE)
-                     .birth(LocalDate.of(2000, 1, 1))
-                     .build()
-        );
-
-        Marathon marathon = new Marathon(
-                organizer,
-                "서울 마라톤",
-                "서울",
-                LocalDate.now().plusDays(10),
-                "poster.png",
-                LocalDateTime.now().minusDays(1),
-                LocalDateTime.now().plusDays(5),
-                MarathonStatus.OPEN
-        );
-
-        Course course = new Course(
-                "10K",
-                BigDecimal.valueOf(30000),
-                100,
-                0
-        );
-
-        marathon.addCourse(course);
-        marathonRepository.save(marathon); // cascade로 course까지 자동 저장
-
-        CreateRegistrationReq req = new CreateRegistrationReq(
-                course.getId(),
-                "12345",
-                "서울시 강남구",
-                "101동",
-                "L",
-                true
-        );
+        CreateRegistrationReq req = createRegistrationReq(course.getId());
 
         CreateRegistrationRes res = registrationCommandService.create(participant.getId(), req);
 
         assertThat(res).isNotNull();
         assertThat(res.registrationId()).isNotNull();
-
-        // 실제 DB에 데이터가 저장(Commit)되었는지 검증
         assertThat(registrationRepository.findById(res.registrationId())).isPresent();
 
-        // 정원이 정상적으로 1명 늘었는지 검증
         Course savedCourse = courseRepository.findById(course.getId()).orElseThrow();
         assertThat(savedCourse.getCurrentCount()).isEqualTo(1);
 
-        // 에러가 발생해도 이메일 발송 시도는 이루어졌는지 검증
         verify(emailService, timeout(2000).atLeastOnce())
-                .sendEmail(anyString(), anyString(), anyString());
+                .sendEmail(eq("participant@test.com"), anyString(), anyString());
     }
 
     @Test
     @DisplayName("참가 접수 성공 시 이메일이 비동기로 발송되고 접수 데이터가 저장된다")
     void registration_success_email_send_test() {
-        Users organizer = userRepository.save(
+        Users organizer = saveOrganizer("organizer-success@test.com");
+        Users participant = saveParticipant("participant-success@test.com");
+        Course course = saveCourseWithMarathon(organizer);
+
+        CreateRegistrationReq req = createRegistrationReq(course.getId());
+
+        CreateRegistrationRes res = registrationCommandService.create(participant.getId(), req);
+
+        assertThat(res).isNotNull();
+        assertThat(res.registrationId()).isNotNull();
+        assertThat(registrationRepository.findById(res.registrationId())).isPresent();
+
+        Course savedCourse = courseRepository.findById(course.getId()).orElseThrow();
+        assertThat(savedCourse.getCurrentCount()).isEqualTo(1);
+
+        verify(emailService, timeout(2000).times(1))
+                .sendEmail(eq("participant-success@test.com"), anyString(), anyString());
+    }
+
+    private Users saveOrganizer(String email) {
+        return userRepository.save(
                 Users.builder()
-                     .email("organizer-success@test.com")
+                     .email(email)
                      .password("1234")
                      .name("주최자")
                      .phoneNumber("010-1111-1111")
@@ -151,10 +119,12 @@ class RegistrationCommandServiceIntegrationTest {
                      .birth(LocalDate.of(1990, 1, 1))
                      .build()
         );
+    }
 
-        Users participant = userRepository.save(
+    private Users saveParticipant(String email) {
+        return userRepository.save(
                 Users.builder()
-                     .email("participant-success@test.com")
+                     .email(email)
                      .password("1234")
                      .name("참가자")
                      .phoneNumber("010-2222-2222")
@@ -163,7 +133,9 @@ class RegistrationCommandServiceIntegrationTest {
                      .birth(LocalDate.of(2000, 1, 1))
                      .build()
         );
+    }
 
+    private Course saveCourseWithMarathon(Users organizer) {
         Marathon marathon = new Marathon(
                 organizer,
                 "서울 마라톤",
@@ -185,30 +157,17 @@ class RegistrationCommandServiceIntegrationTest {
         marathon.addCourse(course);
         marathonRepository.save(marathon);
 
-        CreateRegistrationReq req = new CreateRegistrationReq(
-                course.getId(),
+        return course;
+    }
+
+    private CreateRegistrationReq createRegistrationReq(Long courseId) {
+        return new CreateRegistrationReq(
+                courseId,
                 "12345",
                 "서울시 강남구",
                 "101동",
                 "L",
                 true
         );
-
-        CreateRegistrationRes res = registrationCommandService.create(participant.getId(), req);
-
-        assertThat(res).isNotNull();
-        assertThat(res.registrationId()).isNotNull();
-        assertThat(registrationRepository.findById(res.registrationId())).isPresent();
-
-        Course savedCourse = courseRepository.findById(course.getId()).orElseThrow();
-        assertThat(savedCourse.getCurrentCount()).isEqualTo(1);
-
-        verify(emailService, timeout(2000).times(1))
-                .sendEmail(
-                        eq("participant-success@test.com"),
-                        anyString(),
-                        anyString()
-                );
     }
-
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #93 

## 🛠️ 작업 내용
- `NotificationIntegrationTest` 통합 테스트 작성
  - 트랜잭션 커밋 이후 비동기 이벤트 리스너가 정상 동작하는지 검증  
  - `TestTransaction`을 활용해 `AFTER_COMMIT` 시점 동작 검증
  - 트랜잭션 롤백 시 이벤트가 실행되지 않고 이메일 발송이 이루어지지 않는지 검증

- `RegistrationCommandServiceIntegrationTest` 통합 테스트 작성
  - 참가 신청 성공 시 DB에 접수 데이터가 정상 저장되는지 검증
  - 참가 신청 성공 시 코스 정원(`currentCount`)이 정상 증가하는지 검증
  - 참가 신청 성공 시 이메일 발송이 비동기로 호출되는지 검증 (`Mockito.timeout`)

- 이메일 장애 격리 시나리오 검증
  - `EmailService`를 Mock 처리하여 이메일 발송 예외 상황을 강제로 재현
  - 이메일 발송 실패가 발생해도 참가 신청 메인 트랜잭션은 정상 커밋되는지 검증
  - 비동기 알림 실패가 참가 신청 데이터 저장에 영향을 주지 않음을 검증

## 테스트 흐름
### 참가 신청 이벤트 리스너 커밋 후 실행 흐름
(`async_event_listener_integration_test - NotificationIntegrationTest`)
1. 트랜잭션 내 이벤트 발행
2. 트랜잭션 Commit
3. AFTER_COMMIT 시점에서 이벤트 리스너 실행
4. 비동기 이메일 발송

---

### 참가 신청 이벤트 트랜잭션 롤백 흐름 
(`rollback_event_listener_test - NotificationIntegrationTest`)

1. 이벤트 발행 
2. 트랜잭션 강제 롤백 
3. 이벤트 리스너 실행되지 않음 
4. 이메일 발송되지 않음

---

### 참가 신청 성공 흐름
(`registration_success_email_send_test - RegistrationCommandServiceIntegrationTest`)
1. 참가 신청 요청 
2. 트랜잭션 내에서 Registration 저장 및 정원 증가 
3. 이벤트 발행 (RegistrationCompletedEvent)
4. 트랜잭션 Commit 
5. Commit 이후 비동기 리스너 실행
6. 이메일 발송

---

### 이메일 실패 흐름
(`email_exception_isolation_test - RegistrationCommandServiceIntegrationTest`)

1. 참가 신청 요청 
2. DB 저장 및 Commit 완료 
3. 비동기 리스너에서 이메일 발송 시도 
4. 이메일 예외 발생 
5. 메인 트랜잭션 영향 없음(DB 데이터 유지)


## 테스트 결과 요약
- 트랜잭션 Commit 이후에만 비동기 이벤트 리스너 실행
- 트랜잭션 Rollback 시 이벤트 리스너 실행되지 않음 
- 참가 신청 시 이메일이 비동기로 정상 호출됨
- 이메일 발송 실패가 발생해도 참가 신청 데이터는 정상적으로 DB에 Commit됨

## 🎯 리뷰 포인트
- 통합 테스트 범위가 참가 신청 기반 비동기 알림 흐름을 충분히 검증하는지 확인 부탁드립니다.
- `NotificationIntegrationTest`와 `RegistrationCommandServiceIntegrationTest`를 분리한 구조가 적절한지 확인 부탁드립니다.
- 이메일 실패 시 메인 트랜잭션이 유지되는 장애 격리 시나리오 검증 방식이 적절한지 확인 부탁드립니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?