### PR TITLE
refactor: 내 접수 조회 (#108)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/PageRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/PageRes.java
@@ -1,6 +1,5 @@
 package com.rungo.api.domain.marathon.marathon.dto;
 
-import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import org.springframework.data.domain.Page;
 
 public record PageRes(
@@ -9,7 +8,7 @@ public record PageRes(
         long totalElements,
         int totalPages
 ) {
-    public static PageRes from(Page<Marathon> page) {
+    public static PageRes from(Page<?> page) {
         return new PageRes(
                 page.getNumber(),
                 page.getSize(),

--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationsReadController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationsReadController.java
@@ -2,29 +2,44 @@ package com.rungo.api.domain.registration.controller;
 
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
 import com.rungo.api.domain.registration.dto.RegistrationOverviewRes;
+import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
 import com.rungo.api.domain.registration.service.RegistrationReadService;
 import com.rungo.api.global.response.ApiResponse;
+import com.rungo.api.global.security.SecurityUser;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class RegistrationsReadController {
 
     private final RegistrationReadService registrationReadService;
 
-    // 내 접수 조회
-    // 인증된 사용자의 id를 가져와 접수 목록 조회
+    // 인증된 사용자의 접수 목록 조회
     @GetMapping("/api/v1/registrations/me")
-    public ResponseEntity<ApiResponse<List<MyRegistrationRes>>> getMyRegistrations(@AuthenticationPrincipal(expression = "id") Long userId) {
+    public ResponseEntity<ApiResponse<MyRegistrationRes>> getMyRegistrations(
+            @AuthenticationPrincipal SecurityUser user,
+            @RequestParam(required = false) RegistrationStatus status,
+            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "20") @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+            @Max(value = 100, message = "size는 100 이하여야 합니다.") int size
+    ) {
+        // 신청일 기준 최신순 정렬
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("appliedAt"), Sort.Order.desc("id")));
 
-        List<MyRegistrationRes> result = registrationReadService.getMyRegistrations(userId);
+        MyRegistrationRes result = registrationReadService.getMyRegistrations(user.getId(), status, pageable);
 
         return ResponseEntity.ok(ApiResponse.ok(result));
     }

--- a/backend/src/main/java/com/rungo/api/domain/registration/dto/MyRegistrationRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/dto/MyRegistrationRes.java
@@ -1,49 +1,70 @@
 package com.rungo.api.domain.registration.dto;
 
 
+import com.rungo.api.domain.marathon.marathon.dto.PageRes;
 import com.rungo.api.domain.registration.entity.Registration;
 import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
+import org.springframework.data.domain.Page;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record MyRegistrationRes(
-        Long id,
-        Long marathonId,
-        String marathonTitle,
-        Long courseId,
-        String courseType,
-        RegistrationStatus status,
-        BigDecimal price,
-        LocalDate eventDate,
-        String snapName,
-        String snapPhoneNumber,
-        String snapZipCode,
-        String snapAddress,
-        String snapDetail,
-        String tSize,
-        boolean agreedTerms,
-        LocalDateTime appliedAt
+        List<Item> content,
+        PageRes pageRes
 ) {
-    public static MyRegistrationRes from(Registration registration) {
+    public static MyRegistrationRes from(Page<Registration> page) {
         return new MyRegistrationRes(
-                registration.getId(),
-                registration.getMarathon().getId(),
-                registration.getMarathon().getTitle(),
-                registration.getCourse().getId(),
-                registration.getCourse().getCourseType(),
-                registration.getStatus(),
-                registration.getCourse().getPrice(),
-                registration.getMarathon().getEventDate(),
-                registration.getSnapName(),
-                registration.getSnapPhoneNumber(),
-                registration.getSnapZipCode(),
-                registration.getSnapAddress(),
-                registration.getSnapDetail(),
-                registration.getTSize(),
-                registration.isAgreedTerms(),
-                registration.getAppliedAt()
+                page.getContent().stream()
+                        .map(Item::from)
+                        .toList(),
+                PageRes.from(page)
         );
+    }
+
+    public record Item(
+            Long registrationId,
+            Long marathonId,
+            String marathonTitle,
+            Long courseId,
+            String courseType,
+            RegistrationStatus status,
+            BigDecimal price,
+            LocalDate eventDate,
+
+            String snapName,
+            String snapPhoneNumber,
+            String snapZipCode,
+            String snapAddress,
+            String snapDetail,
+
+            String tSize,
+            boolean agreedTerms,
+            LocalDateTime appliedAt
+    ) {
+        public static Item from(Registration registration) {
+            return new Item(
+                    registration.getId(),
+                    registration.getMarathon().getId(),
+                    registration.getMarathon().getTitle(),
+                    registration.getCourse().getId(),
+                    registration.getCourse().getCourseType(),
+                    registration.getStatus(),
+                    registration.getCourse().getPrice(),
+                    registration.getMarathon().getEventDate(),
+
+                    registration.getSnapName(),
+                    registration.getSnapPhoneNumber(),
+                    registration.getSnapZipCode(),
+                    registration.getSnapAddress(),
+                    registration.getSnapDetail(),
+
+                    registration.getTSize(),
+                    registration.isAgreedTerms(),
+                    registration.getAppliedAt()
+            );
+        }
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -1,6 +1,9 @@
 package com.rungo.api.domain.registration.repository;
 
 import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +13,10 @@ import java.util.List;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     @EntityGraph(attributePaths = {"marathon", "course"})
-    List<Registration> findAllByUser_IdOrderByAppliedAtDesc(Long userId);
+    Page<Registration> findByUser_Id(Long userId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"marathon", "course"})
+    Page<Registration> findByUser_IdAndStatus(Long userId, RegistrationStatus status, Pageable pageable);
 
     @EntityGraph(attributePaths = {"user", "course"})
     List<Registration> findAllByMarathon_IdOrderByAppliedAtDesc(Long marathonId);

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
@@ -7,10 +7,14 @@ import com.rungo.api.domain.registration.dto.CourseRegistrationStatusRes;
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
 import com.rungo.api.domain.registration.dto.RegistrationOverviewRes;
 import com.rungo.api.domain.registration.dto.RegistrationParticipantRes;
+import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,14 +28,20 @@ public class RegistrationReadService {
     private final MarathonRepository marathonRepository;
     private final CourseRepository courseRepository;
 
+    // 내 접수 목록 조회
     @Transactional(readOnly = true)
-    public List<MyRegistrationRes> getMyRegistrations(Long userId) {
+    public MyRegistrationRes getMyRegistrations(Long userId, RegistrationStatus status, Pageable pageable) {
 
-        // 사용자의 id로 DB 조회 후 신청일 기준 내림차순 정렬
-        return registrationRepository.findAllByUser_IdOrderByAppliedAtDesc(userId)
-                .stream()
-                .map(MyRegistrationRes::from)
-                .toList();
+        Page<Registration> page;
+
+        // 상태 필터 없을 시 전체 목록 조회, 있을 시 해당 상태의 목록만 조회
+        if (status == null) {
+            page = registrationRepository.findByUser_Id(userId, pageable);
+        } else {
+            page = registrationRepository.findByUser_IdAndStatus(userId, status, pageable);
+        }
+
+        return MyRegistrationRes.from(page);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/rungo/api/global/springDoc/SpringDoc.java
+++ b/backend/src/main/java/com/rungo/api/global/springDoc/SpringDoc.java
@@ -1,4 +1,4 @@
-package com.rungo.api.global;
+package com.rungo.api.global.springDoc;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;


### PR DESCRIPTION
## 📌 관련 이슈
Closes #108 

## 🛠️ 작업 내용
- [ ] 페이징 처리 적용
- [ ] 상태별 필터링, 신청일 기준 최신순 정렬

## 🎯 리뷰 포인트
- `Controller`와 `Service`에서 `PageRes 공통화를 위해 제네릭 처리`, `상태 필터링`, `신청일 기준 최신순 정렬`, `페이징 처리` 위주로 봐주시면 감사하겠습니다.
- SpringDoc 패키지 경로 오류 수정했습니다.

- 처음엔 마라톤 조회와 달리 접수 조회&접수 현황 조회는 많은 데이터가 필요할 것이라는 생각이 들지 않아 페이징 처리를 하지 않도록 설계하였습니다.
- 하지만, 막상 접수 현황 조회 API를 구현하고 나니 참가자 목록이 상당할 것이라 생각해 느지막이 페이징 처리를 생각하게 되었고, 먼저 내 접수 조회 API에 대한 리팩토링을 진행하였습니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?