### PR TITLE
test: registration 테스트 보정 및 동시성 테스트 추가 (#95)

### DIFF
--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceConcurrencyTest.java
@@ -1,0 +1,246 @@
+package com.rungo.api.domain.registration.service;
+
+import com.rungo.api.domain.marathon.course.entity.Course;
+import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
+import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
+import com.rungo.api.domain.registration.repository.RegistrationRepository;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Gender;
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import com.rungo.api.global.infrastructure.mail.EmailService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+class RegistrationCommandServiceConcurrencyTest {
+
+    @Autowired
+    private RegistrationCommandService registrationCommandService;
+
+    @Autowired
+    private RegistrationRepository registrationRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private MarathonRepository marathonRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @BeforeEach
+    @AfterEach
+    void clearData() {
+        registrationRepository.deleteAllInBatch();
+        courseRepository.deleteAllInBatch();
+        marathonRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("정원이 1명인 코스에 동시에 신청하면 1건만 성공한다")
+    void create_concurrently_only_one_succeeds() throws Exception {
+        Marathon marathon = saveMarathon("서울 마라톤");
+        Course course = saveCourse(marathon, 1, 0);
+        List<Users> participants = saveParticipants(10);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger capacityFullCount = new AtomicInteger();
+        List<Throwable> unexpectedErrors = new ArrayList<>();
+
+        // 여러 요청이 최대한 같은 시점에 create()를 호출하도록 맞춘다.
+        runConcurrently(participants.size(), index -> {
+            try {
+                registrationCommandService.create(
+                        participants.get(index).getId(),
+                        createRequest(course.getId())
+                );
+                successCount.incrementAndGet();
+            } catch (CustomException exception) {
+                if (exception.getErrorCode() == ErrorCode.CAPACITY_FULL) {
+                    capacityFullCount.incrementAndGet();
+                    return;
+                }
+                synchronized (unexpectedErrors) {
+                    unexpectedErrors.add(exception);
+                }
+            } catch (Throwable throwable) {
+                synchronized (unexpectedErrors) {
+                    unexpectedErrors.add(throwable);
+                }
+            }
+        });
+
+        // 최종 정합성은 메모리 값이 아니라 DB에 반영된 상태로 확인한다.
+        System.out.println("동시 신청 결과"
+                + " | 요청 수=" + participants.size()
+                + " | 성공=" + successCount.get()
+                + " | 정원 마감 실패=" + capacityFullCount.get()
+                + " | currentCount=" + findCourse(course.getId()).getCurrentCount()
+                + " | registrationCount=" + registrationRepository.count());
+
+        assertTrue(unexpectedErrors.isEmpty());
+        assertEquals(1, successCount.get());
+        assertEquals(participants.size() - 1, capacityFullCount.get());
+        assertEquals(1, findCourse(course.getId()).getCurrentCount());
+        assertEquals(1, registrationRepository.count());
+    }
+
+    @Test
+    @DisplayName("정원이 100명인 코스에 100명이 동시에 신청하면 모두 성공하고 count가 100이 된다")
+    void create_concurrently_one_hundred_requests_fill_capacity_exactly() throws Exception {
+        // 동시 요청이 몰려도 currentCount와 실제 접수 수가 정확히 누적되는지 확인한다.
+        int requestCount = 100;
+        Marathon marathon = saveMarathon("제주 마라톤");
+        Course course = saveCourse(marathon, requestCount, 0);
+        List<Users> participants = saveParticipants(requestCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        List<Throwable> unexpectedErrors = new ArrayList<>();
+
+        runConcurrently(participants.size(), index -> {
+            try {
+                registrationCommandService.create(
+                        participants.get(index).getId(),
+                        createRequest(course.getId())
+                );
+                successCount.incrementAndGet();
+            } catch (Throwable throwable) {
+                synchronized (unexpectedErrors) {
+                    unexpectedErrors.add(throwable);
+                }
+            }
+        });
+
+        long registrationCount = registrationRepository.count();
+        int currentCount = findCourse(course.getId()).getCurrentCount();
+
+        System.out.println("100명 동시 신청 결과"
+                + " | 요청 수=" + participants.size()
+                + " | 성공=" + successCount.get()
+                + " | 실패=" + unexpectedErrors.size()
+                + " | currentCount=" + currentCount
+                + " | registrationCount=" + registrationCount);
+
+        assertTrue(unexpectedErrors.isEmpty());
+        assertEquals(requestCount, successCount.get());
+        assertEquals(requestCount, currentCount);
+        assertEquals(requestCount, registrationCount);
+    }
+
+    private void runConcurrently(int threadCount, ConcurrentAction action) throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+                futures.add(executorService.submit(() -> {
+                    readyLatch.countDown();
+                    // 모든 스레드가 준비될 때까지 대기했다가 한 번에 출발한다.
+                    startLatch.await();
+                    action.run(index);
+                    return null;
+                }));
+            }
+
+            readyLatch.await();
+            startLatch.countDown();
+
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private List<Users> saveParticipants(int count) {
+        List<Users> participants = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            participants.add(saveUser("participant" + i + "@test.com", Role.PARTICIPANT));
+        }
+        return participants;
+    }
+
+    private Users saveUser(String email, Role role) {
+        return userRepository.saveAndFlush(
+                Users.builder()
+                        .email(email)
+                        .password("encoded-password")
+                        .name(email)
+                        .phoneNumber("010-1111-2222")
+                        .role(role)
+                        .gender(Gender.MALE)
+                        .birth(LocalDate.of(2000, 1, 1))
+                        .build()
+        );
+    }
+
+    private Marathon saveMarathon(String title) {
+        Users organizer = saveUser(title + "@organizer.com", Role.ORGANIZER);
+        return marathonRepository.saveAndFlush(
+                new Marathon(
+                        organizer,
+                        title,
+                        "서울",
+                        LocalDate.of(2026, 10, 3),
+                        "poster.png",
+                        LocalDateTime.now().minusDays(1),
+                        LocalDateTime.now().plusDays(1),
+                        MarathonStatus.OPEN
+                )
+        );
+    }
+
+    private Course saveCourse(Marathon marathon, int capacity, int currentCount) {
+        Course course = new Course("10K", BigDecimal.valueOf(30000), capacity, currentCount);
+        marathon.addCourse(course);
+        marathonRepository.saveAndFlush(marathon);
+        return courseRepository.findAllByMarathon_IdOrderByIdAsc(marathon.getId()).get(0);
+    }
+
+    private CreateRegistrationReq createRequest(Long courseId) {
+        return new CreateRegistrationReq(courseId, "12345", "서울시 강남구", "101동", "L", true);
+    }
+
+    private Course findCourse(Long courseId) {
+        return courseRepository.findById(courseId).orElseThrow();
+    }
+
+    @FunctionalInterface
+    private interface ConcurrentAction {
+        void run(int index) throws Exception;
+    }
+}

--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceTest.java
@@ -4,6 +4,7 @@ import com.rungo.api.domain.marathon.course.entity.Course;
 import com.rungo.api.domain.marathon.course.repository.CourseRepository;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import com.rungo.api.domain.notification.event.RegistrationCompletedEvent;
 import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
 import com.rungo.api.domain.registration.dto.CreateRegistrationRes;
 import com.rungo.api.domain.registration.entity.Registration;
@@ -21,6 +22,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
@@ -51,6 +53,9 @@ class RegistrationCommandServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @Test
     @DisplayName("접수 생성 성공 - 저장과 응답 반환 및 코스 인원 증가가 정상 동작한다")
@@ -83,6 +88,7 @@ class RegistrationCommandServiceTest {
 
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(courseRepository.findById(3L)).willReturn(Optional.of(course));
+        given(courseRepository.increaseCurrentCountIfNotFull(3L)).willReturn(1);
         given(registrationRepository.save(any(Registration.class))).willReturn(savedRegistration);
 
         CreateRegistrationRes result = registrationCommandService.create(1L, request);
@@ -102,7 +108,6 @@ class RegistrationCommandServiceTest {
         assertEquals("101동", capturedRegistration.getSnapDetail());
         assertEquals("L", capturedRegistration.getTSize());
         assertEquals(true, capturedRegistration.isAgreedTerms());
-        assertEquals(11, course.getCurrentCount());
 
         assertNotNull(result);
         assertEquals(4L, result.registrationId());
@@ -110,6 +115,9 @@ class RegistrationCommandServiceTest {
         assertEquals(3L, result.courseId());
         assertEquals("COMPLETED", result.status());
         assertEquals(appliedAt, result.appliedAt());
+
+        verify(courseRepository, times(1)).increaseCurrentCountIfNotFull(3L);
+        verify(eventPublisher, times(1)).publishEvent(any(RegistrationCompletedEvent.class));
     }
 
     @Test
@@ -245,10 +253,12 @@ class RegistrationCommandServiceTest {
                 MarathonStatus.OPEN
         );
         Course course = createCourse(marathon, 10, 10);
+        ReflectionTestUtils.setField(course, "id", 1L);
         CreateRegistrationReq request = new CreateRegistrationReq(1L, "12345", "서울시 강남구", "101동", "L", true);
 
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(courseRepository.findById(1L)).willReturn(Optional.of(course));
+        given(courseRepository.increaseCurrentCountIfNotFull(1L)).willReturn(0);
 
         CustomException exception = assertThrows(
                 CustomException.class,
@@ -268,6 +278,7 @@ class RegistrationCommandServiceTest {
                 MarathonStatus.OPEN
         );
         Course course = createCourse(marathon, 100, 10);
+        ReflectionTestUtils.setField(course, "id", 3L);
         Registration registration = Registration.create(
                 user,
                 course,
@@ -283,8 +294,8 @@ class RegistrationCommandServiceTest {
 
         registrationCommandService.cancel(1L, 1L);
 
+        verify(courseRepository, times(1)).decreaseCurrentCountIfPositive(3L);
         verify(registrationRepository, times(1)).delete(registration);
-        assertEquals(9, course.getCurrentCount());
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #95
`RegistrationCommandServiceIntegrationTest`는 다른 PR과 범위가 겹쳐 이번 PR에서는 제외했습니다.

## 🛠️ 작업 내용
- [x] `RegistrationCommandServiceTest`를 현재 원자적 업데이트 방식에 맞게 보정
- [x] `RegistrationCommandServiceConcurrencyTest` 추가
- [x] 정원 1명 코스 동시 신청 시 1건만 성공하는지 검증
- [x] 정원 100명 코스 동시 신청 시 `currentCount`와 실제 접수 수가 정확히 100건 누적되는지 검증


## 🎯 리뷰 포인트
테스트 케이스가 적절한지 확인 부탁드립니다.
`RegistrationCommandServiceIntegrationTest`는 다른 PR과 범위가 겹쳐 이번 PR에서는 제외했습니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?