### PR TITLE
test: marathon create test (#98)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/create/CreateMarathonReq.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/create/CreateMarathonReq.java
@@ -35,7 +35,7 @@ public record CreateMarathonReq(
         List<CreateCourseItemReq> courses
 ) {
     public record CreateCourseItemReq(
-            @NotNull(message = "코스 타입은 필수입니다.")
+            @NotBlank(message = "코스 타입은 필수입니다.")
             String courseType,
 
             @NotNull(message = "참가비는 필수입니다.")

--- a/backend/src/test/java/com/rungo/api/domain/marathon/controller/MarathonControllerTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/marathon/controller/MarathonControllerTest.java
@@ -1,0 +1,223 @@
+package com.rungo.api.domain.marathon.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rungo.api.domain.marathon.marathon.controller.MarathonController;
+import com.rungo.api.domain.marathon.marathon.dto.CourseItemRes;
+import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonReq;
+import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonRes;
+import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
+import com.rungo.api.domain.marathon.marathon.service.MarathonService;
+import com.rungo.api.global.security.SecurityUser;
+import com.rungo.api.domain.users.enumtype.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(MarathonController.class)
+class MarathonControllerTest {
+
+    @Autowired
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+
+    private MarathonService marathonService;
+
+    @MockitoBean
+    private MarathonRepository marathonRepository;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setAuthenticatedUser(Long userId) {
+        SecurityUser user = new SecurityUser(
+                userId,
+                "test@test.com",
+                Role.ORGANIZER,
+                List.of(new SimpleGrantedAuthority("ROLE_ORGANIZER"))
+        );
+
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        user,
+                        null,
+                        user.getAuthorities()
+                );
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("마라톤 생성 성공 - 201 상태코드와 공통 응답을 반환한다")
+    void create_success() throws Exception {
+
+        setAuthenticatedUser(1L);
+
+        CreateMarathonReq req = new CreateMarathonReq(
+                "서울 마라톤",
+                "서울",
+                LocalDate.of(2026, 10, 3),
+                "poster.png",
+                LocalDateTime.of(2026, 8, 1, 9, 0),
+                LocalDateTime.of(2026, 8, 10, 18, 0),
+                List.of(
+                        new CreateMarathonReq.CreateCourseItemReq(
+                                "10K",
+                                BigDecimal.valueOf(30000),
+                                100
+                        )
+                )
+        );
+
+        CreateMarathonRes res = new CreateMarathonRes(
+                1L,
+                "서울 마라톤",
+                "서울",
+                LocalDate.of(2026, 10, 3),
+                "poster.png",
+                LocalDateTime.of(2026, 8, 1, 9, 0),
+                LocalDateTime.of(2026, 8, 10, 18, 0),
+                MarathonStatus.OPEN,
+                List.of(
+                        new CourseItemRes(
+                                11L,
+                                "10K",
+                                BigDecimal.valueOf(30000),
+                                100,
+                                0,
+                                100
+                        )
+                ),
+                LocalDateTime.of(2026, 7, 1, 12, 0)
+        );
+
+        given(marathonService.createMarathon(eq(1L), eq(req))).willReturn(res);
+
+        mockMvc.perform(post("/api/v1/marathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(1));
+
+        verify(marathonService).createMarathon(eq(1L), eq(req));
+    }
+
+    @Test
+    @DisplayName("마라톤 생성 실패 - title이 없으면 400 반환")
+    void create_fail_title_null() throws Exception {
+
+        setAuthenticatedUser(1L);
+
+        String request = """
+            {
+              "region": "서울",
+              "eventDate": "2026-10-03",
+              "registrationStartAt": "2026-08-01T09:00:00",
+              "registrationEndAt": "2026-08-10T18:00:00",
+              "courses": [
+                {
+                  "courseType": "10K",
+                  "price": 30000,
+                  "capacity": 100
+                }
+              ]
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/marathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"));
+
+        verifyNoInteractions(marathonService);
+    }
+
+    @Test
+    @DisplayName("마라톤 생성 실패 - courses가 비어있으면 400 반환")
+    void create_fail_courses_empty() throws Exception {
+
+        setAuthenticatedUser(1L);
+
+        String request = """
+            {
+              "title": "서울 마라톤",
+              "region": "서울",
+              "eventDate": "2026-10-03",
+              "registrationStartAt": "2026-08-01T09:00:00",
+              "registrationEndAt": "2026-08-10T18:00:00",
+              "courses": []
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/marathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(marathonService);
+    }
+
+    @Test
+    @DisplayName("마라톤 생성 실패 - courseType이 비어있으면 400 반환")
+    void create_fail_courseType_blank() throws Exception {
+
+        setAuthenticatedUser(1L);
+
+        String request = """
+            {
+              "title": "서울 마라톤",
+              "region": "서울",
+              "eventDate": "2026-10-03",
+              "registrationStartAt": "2026-08-01T09:00:00",
+              "registrationEndAt": "2026-08-10T18:00:00",
+              "courses": [
+                {
+                  
+                  "price": 30000,
+                  "capacity": 100
+                }
+              ]
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/marathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(marathonService);
+    }
+}

--- a/backend/src/test/java/com/rungo/api/domain/marathon/controller/MarathonControllerTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/marathon/controller/MarathonControllerTest.java
@@ -192,7 +192,7 @@ class MarathonControllerTest {
 
     @Test
     @DisplayName("마라톤 생성 실패 - courseType이 비어있으면 400 반환")
-    void create_fail_courseType_blank() throws Exception {
+    void create_fail_courseType_Null() throws Exception {
 
         setAuthenticatedUser(1L);
 
@@ -206,6 +206,37 @@ class MarathonControllerTest {
               "courses": [
                 {
                   
+                  "price": 30000,
+                  "capacity": 100
+                }
+              ]
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/marathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(marathonService);
+    }
+
+    @Test
+    @DisplayName("마라톤 생성 실패 - courseType의 문자열에 빈 공백들어 올 시 400 반환")
+    void create_fail_courseType_blank() throws Exception {
+
+        setAuthenticatedUser(1L);
+
+        String request = """
+            {
+              "title": "서울 마라톤",
+              "region": "서울",
+              "eventDate": "2026-10-03",
+              "registrationStartAt": "2026-08-01T09:00:00",
+              "registrationEndAt": "2026-08-10T18:00:00",
+              "courses": [
+                {
+                  "courseType": "   ",
                   "price": 30000,
                   "capacity": 100
                 }

--- a/backend/src/test/java/com/rungo/api/domain/marathon/marathon/service/MarathonServiceTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/marathon/marathon/service/MarathonServiceTest.java
@@ -1,27 +1,38 @@
 package com.rungo.api.domain.marathon.marathon.service;
 
+import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonReq;
+import com.rungo.api.domain.marathon.marathon.dto.create.CreateMarathonRes;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.notification.event.MarathonCanceledEvent;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Gender;
 import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -76,5 +87,373 @@ class MarathonServiceTest {
 
         verify(eventPublisher, times(1))
                 .publishEvent(any(MarathonCanceledEvent.class));
+    }
+
+    @Test
+
+    @DisplayName("마라톤 생성 성공 - 저장과 응답 반환 및 코스 정규화가 정상 동작한다")
+
+    void create_success() {
+
+        Long organizerId = 1L;
+
+        Users organizer = createUser(organizerId, "주최자", Role.ORGANIZER);
+
+        CreateMarathonReq request = new CreateMarathonReq(
+
+                "서울 마라톤",
+
+                "서울",
+
+                LocalDate.of(2026, 10, 3),
+
+                "poster.png",
+
+                LocalDateTime.of(2026, 8, 1, 9, 0),
+
+                LocalDateTime.of(2026, 8, 31, 18, 0),
+
+                List.of(
+
+                        new CreateMarathonReq.CreateCourseItemReq("5k", new BigDecimal("30000"), 100),
+
+                        new CreateMarathonReq.CreateCourseItemReq("10K", new BigDecimal("50000"), 200)
+
+                )
+
+        );
+
+        given(userRepository.findById(organizerId)).willReturn(Optional.of(organizer));
+
+        given(marathonRepository.save(any(Marathon.class))).willAnswer(invocation -> {
+
+            Marathon saved = invocation.getArgument(0);
+
+            ReflectionTestUtils.setField(saved, "id", 10L);
+
+            return saved;
+
+        });
+
+        CreateMarathonRes result = marathonService.createMarathon(organizerId, request);
+
+        ArgumentCaptor<Marathon> marathonCaptor = ArgumentCaptor.forClass(Marathon.class);
+
+        verify(marathonRepository, times(1)).save(marathonCaptor.capture());
+
+        Marathon capturedMarathon = marathonCaptor.getValue();
+
+        assertSame(organizer, capturedMarathon.getOrganizer());
+
+        assertEquals("서울 마라톤", capturedMarathon.getTitle());
+
+        assertEquals("서울", capturedMarathon.getRegion());
+
+        assertEquals(LocalDate.of(2026, 10, 3), capturedMarathon.getEventDate());
+
+        assertEquals("poster.png", capturedMarathon.getPosterImageUrl());
+
+        assertEquals(LocalDateTime.of(2026, 8, 1, 9, 0), capturedMarathon.getRegistrationStartAt());
+
+        assertEquals(LocalDateTime.of(2026, 8, 31, 18, 0), capturedMarathon.getRegistrationEndAt());
+
+        assertEquals(MarathonStatus.OPEN, capturedMarathon.getStatus());
+
+        assertEquals(2, capturedMarathon.getCourses().size());
+
+        assertEquals("5K", capturedMarathon.getCourses().get(0).getCourseType());
+
+        assertEquals(new BigDecimal("30000"), capturedMarathon.getCourses().get(0).getPrice());
+
+        assertEquals(100, capturedMarathon.getCourses().get(0).getCapacity());
+
+        assertEquals(0, capturedMarathon.getCourses().get(0).getCurrentCount());
+
+        assertEquals("10K", capturedMarathon.getCourses().get(1).getCourseType());
+
+        assertEquals(new BigDecimal("50000"), capturedMarathon.getCourses().get(1).getPrice());
+
+        assertEquals(200, capturedMarathon.getCourses().get(1).getCapacity());
+
+        assertEquals(0, capturedMarathon.getCourses().get(1).getCurrentCount());
+
+        assertNotNull(result);
+
+        assertEquals(10L, result.id());
+
+        assertEquals("서울 마라톤", result.title());
+
+        assertEquals("서울", result.region());
+
+        assertEquals(LocalDate.of(2026, 10, 3), result.eventDate());
+
+        assertEquals("poster.png", result.posterImageUrl());
+
+        assertEquals(LocalDateTime.of(2026, 8, 1, 9, 0), result.registrationStartAt());
+
+        assertEquals(LocalDateTime.of(2026, 8, 31, 18, 0), result.registrationEndAt());
+
+        assertEquals(MarathonStatus.OPEN, result.status());
+
+        assertEquals(2, result.courses().size());
+
+        assertEquals("5K", result.courses().get(0).courseType());
+
+        assertEquals("10K", result.courses().get(1).courseType());
+
+    }
+
+    @Test
+
+    @DisplayName("마라톤 생성 실패 - 사용자가 없으면 USER_NOT_FOUND 예외가 발생한다")
+
+    void create_fail_user_not_found() {
+
+        Long organizerId = 1L;
+
+        CreateMarathonReq request = new CreateMarathonReq(
+
+                "서울 마라톤",
+
+                "서울",
+
+                LocalDate.of(2026, 10, 3),
+
+                "poster.png",
+
+                LocalDateTime.of(2026, 8, 1, 9, 0),
+
+                LocalDateTime.of(2026, 8, 31, 18, 0),
+
+                List.of(
+
+                        new CreateMarathonReq.CreateCourseItemReq("5K", new BigDecimal("30000"), 100)
+
+                )
+
+        );
+
+        given(userRepository.findById(organizerId)).willReturn(Optional.empty());
+
+        CustomException exception = assertThrows(
+
+                CustomException.class,
+
+                () -> marathonService.createMarathon(organizerId, request)
+
+        );
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+
+    }
+
+    @Test
+
+    @DisplayName("마라톤 생성 실패 - 주최자 권한이 아니면 FORBIDDEN 예외가 발생한다")
+
+    void create_fail_not_organizer() {
+
+        Long organizerId = 1L;
+
+        Users participant = createUser(organizerId, "참가자", Role.PARTICIPANT);
+
+        CreateMarathonReq request = new CreateMarathonReq(
+
+                "서울 마라톤",
+
+                "서울",
+
+                LocalDate.of(2026, 10, 3),
+
+                "poster.png",
+
+                LocalDateTime.of(2026, 8, 1, 9, 0),
+
+                LocalDateTime.of(2026, 8, 31, 18, 0),
+
+                List.of(
+
+                        new CreateMarathonReq.CreateCourseItemReq("5K", new BigDecimal("30000"), 100)
+
+                )
+
+        );
+
+        given(userRepository.findById(organizerId)).willReturn(Optional.of(participant));
+
+        CustomException exception = assertThrows(
+
+                CustomException.class,
+
+                () -> marathonService.createMarathon(organizerId, request)
+
+        );
+
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+
+    }
+
+    @Test
+
+    @DisplayName("마라톤 생성 실패 - 접수 시작일이 종료일보다 늦으면 INVALID_INPUT_VALUE 예외가 발생한다")
+
+    void create_fail_registration_period_invalid() {
+
+        Long organizerId = 1L;
+
+        Users organizer = createUser(organizerId, "주최자", Role.ORGANIZER);
+
+        CreateMarathonReq request = new CreateMarathonReq(
+
+                "서울 마라톤",
+
+                "서울",
+
+                LocalDate.of(2026, 10, 3),
+
+                "poster.png",
+
+                LocalDateTime.of(2026, 9, 1, 9, 0),
+
+                LocalDateTime.of(2026, 8, 31, 18, 0),
+
+                List.of(
+
+                        new CreateMarathonReq.CreateCourseItemReq("5K", new BigDecimal("30000"), 100)
+
+                )
+
+        );
+
+        given(userRepository.findById(organizerId)).willReturn(Optional.of(organizer));
+
+        CustomException exception = assertThrows(
+
+                CustomException.class,
+
+                () -> marathonService.createMarathon(organizerId, request)
+
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+
+    }
+
+    @Test
+
+    @DisplayName("마라톤 생성 실패 - 개최일이 접수 종료일보다 이르면 INVALID_INPUT_VALUE 예외가 발생한다")
+
+    void create_fail_event_date_invalid() {
+
+        Long organizerId = 1L;
+
+        Users organizer = createUser(organizerId, "주최자", Role.ORGANIZER);
+
+        CreateMarathonReq request = new CreateMarathonReq(
+
+                "서울 마라톤",
+
+                "서울",
+
+                LocalDate.of(2026, 8, 20),
+
+                "poster.png",
+
+                LocalDateTime.of(2026, 8, 1, 9, 0),
+
+                LocalDateTime.of(2026, 8, 31, 18, 0),
+
+                List.of(
+
+                        new CreateMarathonReq.CreateCourseItemReq("5K", new BigDecimal("30000"), 100)
+
+                )
+
+        );
+
+        given(userRepository.findById(organizerId)).willReturn(Optional.of(organizer));
+
+        CustomException exception = assertThrows(
+
+                CustomException.class,
+
+                () -> marathonService.createMarathon(organizerId, request)
+
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+
+    }
+
+    @Test
+
+    @DisplayName("마라톤 생성 실패 - 코스 타입이 정규화 후 중복되면 INVALID_INPUT_VALUE 예외가 발생한다")
+
+    void create_fail_duplicate_course_type() {
+
+        Long organizerId = 1L;
+
+        Users organizer = createUser(organizerId, "주최자", Role.ORGANIZER);
+
+        CreateMarathonReq request = new CreateMarathonReq(
+
+                "서울 마라톤",
+
+                "서울",
+
+                LocalDate.of(2026, 10, 3),
+
+                "poster.png",
+
+                LocalDateTime.of(2026, 8, 1, 9, 0),
+
+                LocalDateTime.of(2026, 8, 31, 18, 0),
+
+                List.of(
+
+                        new CreateMarathonReq.CreateCourseItemReq("5k", new BigDecimal("30000"), 100),
+
+                        new CreateMarathonReq.CreateCourseItemReq(" 5K ", new BigDecimal("50000"), 200)
+
+                )
+
+        );
+
+        given(userRepository.findById(organizerId)).willReturn(Optional.of(organizer));
+
+        CustomException exception = assertThrows(
+
+                CustomException.class,
+
+                () -> marathonService.createMarathon(organizerId, request)
+
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+
+    }
+
+    private Users createUser(Long id, String name, Role role) {
+
+        return Users.builder()
+
+                .id(id)
+
+                .email("test@test.com")
+
+                .password("encoded-password")
+
+                .name(name)
+
+                .phoneNumber("010-1111-2222")
+
+                .role(role)
+
+                .gender(Gender.MALE)
+
+                .birth(LocalDate.of(2000, 1, 1))
+
+                .build();
+
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

마라톤 Create 테스트 
Closes #98 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 마라톤 Service 대회생성 테스트 코드 추가
- [x] 마라톤 Controller 대회생성 테스트 코드 추가



## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
## 🎯 리뷰 포인트
먼저, 마라톤 대회를 생성할때, 해당 코스의 타입의 기입은 필수적이기에, NotNull에서 NotBlank로 변경하였습니다.

Controller / Service 테스트를 분리하여 작성했습니다.

### 1. Controller 테스트

- 마라톤 생성 성공

- 요청값 유효성 검증 실패

- 코스 내부 DTO 검증 실패

### 2. Service 테스트

- 마라톤 생성 성공

- 사용자/권한 검증 실패

- 날짜 정책 검증 실패

- 코스 정책 검증 실패

모든 검증 실패는 정의한 예외 처리로 정상적으로 분기되는지 함께 확인했습니다.
혹시 추가로 고려해야 할 테스트 케이스가 있다면 피드백 부탁드립니다!
## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?