### PR TITLE
feat: 접수 취소 이력 엔티티 및 레포지토리 추가 (#125)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/entity/RegistrationCancelHistory.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/entity/RegistrationCancelHistory.java
@@ -2,6 +2,7 @@ package com.rungo.api.domain.registration.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -10,6 +11,8 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -25,6 +28,7 @@ import java.time.LocalDateTime;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class RegistrationCancelHistory {
 
     @Id
@@ -67,6 +71,7 @@ public class RegistrationCancelHistory {
     @Column(name = "applied_at", nullable = false)
     private LocalDateTime appliedAt;
 
+    @CreatedDate
     @Column(name = "canceled_at", nullable = false)
     private LocalDateTime canceledAt;
 
@@ -82,8 +87,7 @@ public class RegistrationCancelHistory {
             String snapDetail,
             String tSize,
             boolean agreedTerms,
-            LocalDateTime appliedAt,
-            LocalDateTime canceledAt
+            LocalDateTime appliedAt
     ) {
         this.originalRegistrationId = originalRegistrationId;
         this.userId = userId;
@@ -97,10 +101,9 @@ public class RegistrationCancelHistory {
         this.tSize = tSize;
         this.agreedTerms = agreedTerms;
         this.appliedAt = appliedAt;
-        this.canceledAt = canceledAt;
     }
 
-    public static RegistrationCancelHistory create(Registration registration, LocalDateTime canceledAt) {
+    public static RegistrationCancelHistory create(Registration registration) {
         return new RegistrationCancelHistory(
                 registration.getId(),
                 registration.getUser().getId(),
@@ -113,8 +116,7 @@ public class RegistrationCancelHistory {
                 registration.getSnapDetail(),
                 registration.getTSize(),
                 registration.isAgreedTerms(),
-                registration.getAppliedAt(),
-                canceledAt
+                registration.getAppliedAt()
         );
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/entity/RegistrationCancelHistory.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/entity/RegistrationCancelHistory.java
@@ -1,0 +1,120 @@
+package com.rungo.api.domain.registration.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "registration_cancel_histories",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_registration_cancel_history_original_registration_id",
+                        columnNames = {"original_registration_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RegistrationCancelHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "original_registration_id", nullable = false)
+    private Long originalRegistrationId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "marathon_id", nullable = false)
+    private Long marathonId;
+
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
+
+    @Column(name = "snap_name", nullable = false, length = 50)
+    private String snapName;
+
+    @Column(name = "snap_phone_number", nullable = false, length = 20)
+    private String snapPhoneNumber;
+
+    @Column(name = "snap_zip_code", nullable = false, length = 10)
+    private String snapZipCode;
+
+    @Column(name = "snap_address", nullable = false, length = 255)
+    private String snapAddress;
+
+    @Column(name = "snap_detail", length = 255)
+    private String snapDetail;
+
+    @Column(name = "t_size", nullable = false, length = 10)
+    private String tSize;
+
+    @Column(name = "agreed_terms", nullable = false)
+    private boolean agreedTerms;
+
+    @Column(name = "applied_at", nullable = false)
+    private LocalDateTime appliedAt;
+
+    @Column(name = "canceled_at", nullable = false)
+    private LocalDateTime canceledAt;
+
+    private RegistrationCancelHistory(
+            Long originalRegistrationId,
+            Long userId,
+            Long marathonId,
+            Long courseId,
+            String snapName,
+            String snapPhoneNumber,
+            String snapZipCode,
+            String snapAddress,
+            String snapDetail,
+            String tSize,
+            boolean agreedTerms,
+            LocalDateTime appliedAt,
+            LocalDateTime canceledAt
+    ) {
+        this.originalRegistrationId = originalRegistrationId;
+        this.userId = userId;
+        this.marathonId = marathonId;
+        this.courseId = courseId;
+        this.snapName = snapName;
+        this.snapPhoneNumber = snapPhoneNumber;
+        this.snapZipCode = snapZipCode;
+        this.snapAddress = snapAddress;
+        this.snapDetail = snapDetail;
+        this.tSize = tSize;
+        this.agreedTerms = agreedTerms;
+        this.appliedAt = appliedAt;
+        this.canceledAt = canceledAt;
+    }
+
+    public static RegistrationCancelHistory create(Registration registration, LocalDateTime canceledAt) {
+        return new RegistrationCancelHistory(
+                registration.getId(),
+                registration.getUser().getId(),
+                registration.getMarathon().getId(),
+                registration.getCourse().getId(),
+                registration.getSnapName(),
+                registration.getSnapPhoneNumber(),
+                registration.getSnapZipCode(),
+                registration.getSnapAddress(),
+                registration.getSnapDetail(),
+                registration.getTSize(),
+                registration.isAgreedTerms(),
+                registration.getAppliedAt(),
+                canceledAt
+        );
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationCancelHistoryRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationCancelHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.rungo.api.domain.registration.repository;
+
+import com.rungo.api.domain.registration.entity.RegistrationCancelHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegistrationCancelHistoryRepository extends JpaRepository<RegistrationCancelHistory, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #125

## 🛠️ 작업 내용
- [x] `RegistrationCancelHistory` 엔티티 추가
- [x] `RegistrationCancelHistoryRepository` 추가
- [x] 추가 필드
  - `originalRegistrationId` (원본 접수 ID)
  - `userId` (참가자 ID)
  - `marathonId` (마라톤 ID)
  - `courseId` (코스 ID)
  - `snapName` (신청 당시 이름)
  - `snapPhoneNumber` (신청 당시 전화번호)
  - `snapZipCode` (신청 당시 우편번호)
  - `snapAddress` (신청 당시 주소)
  - `snapDetail` (신청 당시 상세주소)
  - `tSize` (신청 당시 티셔츠 사이즈)
  - `agreedTerms` (필수 약관 동의 여부)
  - `appliedAt` (접수 생성 시각)
  - `canceledAt` (접수 취소 시각)

## 🎯 리뷰 포인트
취소 이력 엔티티 필드 구성이 현재 비즈니스 요구사항에 충분한지 확인 부탁드립니다!

마라톤은 접수가 시작되면 수정이 불가능해서, 취소 내역 조회 시 해당 필드들을 취소 이력 테이블에 저장하지 않고 `marathonId`, `courseId` 기반 재조회로 처리해도 될 것 같다고 판단했는데 확인 부탁드립니다!



## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?