### PR TITLE
feat: admin approve orginzer (#118)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.rungo.api.domain.users.admin.controller;
 
 import com.rungo.api.domain.users.admin.service.AdminService;
+import com.rungo.api.domain.users.dto.MyProfileRes;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.global.response.ApiResponse;
 import com.rungo.api.global.security.SecurityUser;
@@ -24,7 +25,7 @@ public class AdminController {
 
     @PatchMapping("/{userId}/organizer")
 
-    public ResponseEntity<ApiResponse<Void>> approveOrganizer(
+    public ResponseEntity<ApiResponse<MyProfileRes>> approveOrganizer(
 
             @AuthenticationPrincipal SecurityUser admin,
 
@@ -32,9 +33,9 @@ public class AdminController {
 
     ) {
 
-        adminService.approveOrganizer(admin.getId(), userId);
+        MyProfileRes myProfileRes =adminService.approveOrganizer(admin.getId(), userId);
 
-        return ResponseEntity.ok(ApiResponse.okMessage("주최자 권한이 부여됐습니다."));
+        return ResponseEntity.ok(ApiResponse.ok(myProfileRes));
 
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
@@ -1,0 +1,4 @@
+package com.rungo.api.domain.users.admin.controller;
+
+public class AdminController {
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
@@ -1,4 +1,40 @@
 package com.rungo.api.domain.users.admin.controller;
 
+import com.rungo.api.domain.users.admin.service.AdminService;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.global.response.ApiResponse;
+import com.rungo.api.global.security.SecurityUser;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/v1/admin")
 public class AdminController {
+
+    private final AdminService adminService;
+
+    @PatchMapping("/{userId}/organizer")
+
+    public ResponseEntity<ApiResponse<Void>> approveOrganizer(
+
+            @AuthenticationPrincipal SecurityUser admin,
+
+            @PathVariable @NotNull Long userId
+
+    ) {
+
+        adminService.approveOrganizer(admin.getId(), userId);
+
+        return ResponseEntity.ok(ApiResponse.okMessage("주최자 권한이 부여됐습니다."));
+
+    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.rungo.api.domain.users.admin.controller;
 
+import com.rungo.api.domain.users.admin.dto.AdminApproveRes;
 import com.rungo.api.domain.users.admin.service.AdminService;
 import com.rungo.api.domain.users.dto.MyProfileRes;
 import com.rungo.api.domain.users.entity.Users;
@@ -25,7 +26,7 @@ public class AdminController {
 
     @PatchMapping("/{userId}/organizer")
 
-    public ResponseEntity<ApiResponse<MyProfileRes>> approveOrganizer(
+    public ResponseEntity<ApiResponse<AdminApproveRes>> approveOrganizer(
 
             @AuthenticationPrincipal SecurityUser admin,
 
@@ -33,9 +34,9 @@ public class AdminController {
 
     ) {
 
-        MyProfileRes myProfileRes =adminService.approveOrganizer(admin.getId(), userId);
+        AdminApproveRes adminApproveRes =adminService.approveOrganizer(admin.getId(), userId);
 
-        return ResponseEntity.ok(ApiResponse.ok(myProfileRes));
+        return ResponseEntity.ok(ApiResponse.ok(adminApproveRes));
 
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/users/admin/dto/AdminApproveRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/dto/AdminApproveRes.java
@@ -1,0 +1,17 @@
+package com.rungo.api.domain.users.admin.dto;
+
+import com.rungo.api.domain.users.enumtype.Gender;
+import com.rungo.api.domain.users.enumtype.Role;
+
+import java.time.LocalDate;
+
+public record AdminApproveRes (
+        Long id,
+        String email,
+        String name,
+        String phoneNumber,
+        Gender gender,
+        LocalDate birth,
+        Role role
+){
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/admin/service/AdminService.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.rungo.api.domain.users.admin.service;
 
+import com.rungo.api.domain.users.admin.dto.AdminApproveRes;
 import com.rungo.api.domain.users.dto.MyProfileRes;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Role;
@@ -16,7 +17,7 @@ public class AdminService {
     private final UserRepository userRepository;
 
     @Transactional
-    public MyProfileRes approveOrganizer(Long adminId, Long userId) {
+    public AdminApproveRes approveOrganizer(Long adminId, Long userId) {
 
         Users admin = userRepository.findById(adminId)
 
@@ -40,7 +41,7 @@ public class AdminService {
 
         user.promoteToOrganizer();
 
-        return new MyProfileRes(
+        return new AdminApproveRes(
                 user.getId(),
                 user.getEmail(),
                 user.getName(),

--- a/backend/src/main/java/com/rungo/api/domain/users/admin/service/AdminService.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/service/AdminService.java
@@ -1,0 +1,43 @@
+package com.rungo.api.domain.users.admin.service;
+
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void approveOrganizer(Long adminId, Long userId) {
+
+        Users admin = userRepository.findById(adminId)
+
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (admin.getRole() != Role.ADMIN) {
+
+            throw new CustomException(ErrorCode.FORBIDDEN);
+
+        }
+
+        Users user = userRepository.findById(userId)
+
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getRole() == Role.ORGANIZER) {
+
+            throw new CustomException(ErrorCode.ALREADY_ORGANIZER);
+
+        }
+
+        user.promoteToOrganizer();
+
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/admin/service/AdminService.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.rungo.api.domain.users.admin.service;
 
+import com.rungo.api.domain.users.dto.MyProfileRes;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
@@ -15,7 +16,7 @@ public class AdminService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void approveOrganizer(Long adminId, Long userId) {
+    public MyProfileRes approveOrganizer(Long adminId, Long userId) {
 
         Users admin = userRepository.findById(adminId)
 
@@ -39,5 +40,14 @@ public class AdminService {
 
         user.promoteToOrganizer();
 
+        return new MyProfileRes(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPhoneNumber(),
+                user.getGender(),
+                user.getBirth(),
+                user.getRole()
+        );
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
@@ -61,4 +61,8 @@ public class Users {
         this.phoneNumber = phoneNumber;
     }
 
+    //주최자로 승급
+    public void promoteToOrganizer() {
+        this.role = Role.ORGANIZER;
+    }
 }

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
-
+    ALREADY_ORGANIZER(HttpStatus.BAD_REQUEST, "이미 주최자 권한을 가진 회원입니다."),
     // 토큰
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),

--- a/backend/src/test/java/com/rungo/api/domain/users/admin/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/users/admin/controller/AdminControllerTest.java
@@ -1,0 +1,75 @@
+package com.rungo.api.domain.users.admin.controller;
+
+import com.rungo.api.domain.users.admin.service.AdminService;
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import com.rungo.api.global.security.SecurityUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(AdminController.class)
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminService adminService;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("주최자 권한 부여 성공 - 200 상태코드와 공통 응답 규격을 반환한다")
+    void approve_organizer_success() throws Exception {
+        setAuthenticatedAdmin(1L);
+
+        mockMvc.perform(patch("/api/v1/admin/{userId}/organizer", 2L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("주최자 권한이 부여됐습니다."));
+
+        verify(adminService).approveOrganizer(1L, 2L);
+    }
+
+    //테스트용 관리자 설정 메서드
+    private void setAuthenticatedAdmin(Long userId) {
+        SecurityUser securityUser = new SecurityUser(
+                userId,
+                "admin@test.com",
+                Role.ADMIN,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        securityUser,
+                        null,
+                        securityUser.getAuthorities()
+                );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/backend/src/test/java/com/rungo/api/domain/users/admin/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/users/admin/service/AdminServiceTest.java
@@ -1,0 +1,119 @@
+package com.rungo.api.domain.users.admin.service;
+
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Gender;
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("주최자 권한 부여 성공 - 관리자가 참가자 유저를 ORGANIZER로 승급시킨다")
+    void approve_organizer_success() {
+        Users admin = createUser(1L, "관리자", Role.ADMIN);
+        Users participant = createUser(2L, "참가자", Role.PARTICIPANT);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+        given(userRepository.findById(2L)).willReturn(Optional.of(participant));
+
+        adminService.approveOrganizer(1L, 2L);
+
+        assertEquals(Role.ORGANIZER, participant.getRole());
+    }
+
+    @Test
+    @DisplayName("주최자 권한 부여 실패 - 관리자 유저가 없으면 USER_NOT_FOUND 예외가 발생한다")
+    void approve_organizer_fail_admin_not_found() {
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> adminService.approveOrganizer(1L, 2L)
+        );
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("주최자 권한 부여 실패 - 관리자가 아니면 FORBIDDEN 예외가 발생한다")
+    void approve_organizer_fail_not_admin() {
+        Users participant = createUser(1L, "참가자", Role.PARTICIPANT);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(participant));
+
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> adminService.approveOrganizer(1L, 2L)
+        );
+
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("주최자 권한 부여 실패 - 대상 유저가 없으면 USER_NOT_FOUND 예외가 발생한다")
+    void approve_organizer_fail_target_user_not_found() {
+        Users admin = createUser(1L, "관리자", Role.ADMIN);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+        given(userRepository.findById(2L)).willReturn(Optional.empty());
+
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> adminService.approveOrganizer(1L, 2L)
+        );
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("주최자 권한 부여 실패 - 이미 주최자면 ALREADY_ORGANIZER 예외가 발생한다")
+    void approve_organizer_fail_already_organizer() {
+        Users admin = createUser(1L, "관리자", Role.ADMIN);
+        Users organizer = createUser(2L, "주최자", Role.ORGANIZER);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+        given(userRepository.findById(2L)).willReturn(Optional.of(organizer));
+
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> adminService.approveOrganizer(1L, 2L)
+        );
+
+        assertEquals(ErrorCode.ALREADY_ORGANIZER, exception.getErrorCode());
+    }
+
+    private Users createUser(Long id, String name, Role role) {
+        return Users.builder()
+                .id(id)
+                .email(name + "@test.com")
+                .password("encoded-password")
+                .name(name)
+                .phoneNumber("010-1111-2222")
+                .role(role)
+                .gender(Gender.MALE)
+                .birth(LocalDate.of(2000, 1, 1))
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #118 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 관리자 도메인 분리
- [x] admin Service, admin Controller 구현
- [x] 권한 부여 기능 구현
- [x] 권한 부여 기능 테스트 코드 작성 및 확인


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
PR의 양 많은점 죄송합니다

###1. 도메인 관련
* 저는 Admin이 User의 일부분이지만, 관리자로서의 역할이 많아질 것을 대비해 User패키지에 하위 패키지로 Admin을 제작하였습니다. 

###2. 요청용 DTO
실제 서비스였다면 권한 부여 요청을 할때 자격 검증(사업자 등록증, 통장 사본, 등등)을 해야겠지만, 이것은 추후에 팀내에서 토의를 하고 구현을 해야 된다 생각해서 요청DTO로 아무것도 받지 않게 구현하였습니다.

###3. 응답용 DTO
권한 부여가 성공적으로 작동되면, 주최측 권한을 받은 사람의 신상 정보가 나오도록 MyProfileRes를 일단 사용하여 보여주도록 하였습니다. 이 부분에서 결합도가 조금 올라갈 것 같은데 같은 필드를 가지는 DTO를 따로 만드는 것이 좋을지 판단 부탁드립니다.

###4. Service 관련
* 제가 구현한 로직은 요청이 들어오면, Role이 Admin인 사람이 Participant인 유저를  Orginzer로 Role을 변환해주는 형태입니다. 


###5. Service쪽 예외 처리
제가 산정한 예외 상황들은 다음과 같습니다.
* 1.권한 부여 해주는 사람의 Role이 Admin이 아닌 경우
* 2.권한 부여를 받는 사람이 DB에 존재하지 않을 경우
* 3.권한 부여를 받는 사람의 Role이 이미 Organizer인 경우

이 예외상황들이 적절한지 판단해주시면 감사하겠습니다.

###6. 테스트 코드

현재 제 테스트 케이스는 다음과 같습니다.

#### Admin Controller Test

- 주최자 권한 부여 성공
- 
#### Admin Service Test

- 주최자 권한 부여 성공

- 주최자 권한 부여 실패 - 관리자 유저가 존재하지 않는 경우

- 주최자 권한 부여 실패 - 관리자 권한이 아닌 경우

- 주최자 권한 부여 실패 - 대상 유저가 존재하지 않는 경우

- 주최자 권한 부여 실패 - 이미 주최자 권한을 가진 경우

해당 테스트 케이스들 적절한지 판단 부탁드립니다!


이 부분들에서, 수정사항이나 개선점 말씀해주시면 감사하겠습니다!
## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?