### PR TITLE
refactor: 비동기 이메일 알림 리팩토링 (#129)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -41,7 +41,11 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
 	// 이메일 발송 의존성 추가
-	implementation("org.springframework.boot:spring-boot-starter-mail")}
+	implementation("org.springframework.boot:spring-boot-starter-mail")
+
+	implementation("org.springframework.retry:spring-retry")
+	implementation("org.springframework.boot:spring-boot-starter-aop")
+}
 
 tasks.withType<Test> {
 	useJUnitPlatform()

--- a/backend/src/main/java/com/rungo/api/domain/notification/listener/NotificationEventListener.java
+++ b/backend/src/main/java/com/rungo/api/domain/notification/listener/NotificationEventListener.java
@@ -2,6 +2,7 @@ package com.rungo.api.domain.notification.listener;
 
 import com.rungo.api.domain.notification.event.MarathonCanceledEvent;
 import com.rungo.api.domain.notification.event.RegistrationCompletedEvent;
+import com.rungo.api.domain.notification.support.NotificationEmailFactory;
 import com.rungo.api.global.infrastructure.mail.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -14,23 +15,27 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class NotificationEventListener {
 
     private final EmailService emailService;
+    private final NotificationEmailFactory notificationEmailFactory;
 
     @Async("mailExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRegistrationCompleted(RegistrationCompletedEvent event) {
-        String subject = "[Rungo] " + event.marathonTitle() + " 참가 접수 완료 안내";
-        String body = String.format("안녕하세요!\n\n%s 대회의 [%s] 코스 접수가 정상적으로 완료되었습니다.",
-                event.marathonTitle(), event.courseName());
-        emailService.sendEmail(event.email(), subject, body);
+        emailService.send(
+                notificationEmailFactory.registrationCompleted(
+                        event.email(),
+                        event.marathonTitle(),
+                        event.courseName()
+                )
+        );
     }
 
     @Async("mailExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMarathonCanceled(MarathonCanceledEvent event) {
-        String subject = "[Rungo] " + event.marathonTitle() + " 대회 취소 안내";
-        String body = "주최측 사정으로 인해 " + event.marathonTitle() + " 대회가 취소되었습니다.\n자세한 사항은 홈페이지를 참고 바랍니다.";
         for (String email : event.participantEmails()) {
-            emailService.sendEmail(email, subject, body);
+            emailService.send(
+                    notificationEmailFactory.marathonCanceled(email, event.marathonTitle())
+            );
         }
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/notification/support/NotificationEmailFactory.java
+++ b/backend/src/main/java/com/rungo/api/domain/notification/support/NotificationEmailFactory.java
@@ -1,0 +1,74 @@
+package com.rungo.api.domain.notification.support;
+
+import com.rungo.api.global.infrastructure.mail.EmailMessage;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class NotificationEmailFactory {
+
+    public EmailMessage registrationCompleted(String email, String marathonTitle, String courseName) {
+        String subject = "[Rungo] " + marathonTitle + " 참가 접수 완료 안내";
+        String body = String.format(
+                """
+                안녕하세요!
+
+                %s 대회의 [%s] 코스 접수가 정상적으로 완료되었습니다.
+                마이페이지에서 접수 내역을 확인하실 수 있습니다.
+                """,
+                marathonTitle,
+                courseName
+        );
+
+        return new EmailMessage(email, subject, body);
+    }
+
+    public EmailMessage marathonCanceled(String email, String marathonTitle) {
+        String subject = "[Rungo] " + marathonTitle + " 대회 취소 안내";
+        String body = String.format(
+                """
+                안녕하세요!
+
+                주최측 사정으로 인해 %s 대회가 취소되었습니다.
+                자세한 사항은 홈페이지를 참고 바랍니다.
+                """,
+                marathonTitle
+        );
+
+        return new EmailMessage(email, subject, body);
+    }
+
+    public EmailMessage paymentCompleted(String email, String marathonTitle, String courseName, BigDecimal amount) {
+        String subject = "[Rungo] " + marathonTitle + " 결제 완료 안내";
+        String body = String.format(
+                """
+                안녕하세요!
+
+                %s 대회의 [%s] 코스 결제가 완료되었습니다.
+                결제 금액: %s원
+                """,
+                marathonTitle,
+                courseName,
+                amount
+        );
+
+        return new EmailMessage(email, subject, body);
+    }
+
+    public EmailMessage refundCompleted(String email, String marathonTitle, BigDecimal amount) {
+        String subject = "[Rungo] " + marathonTitle + " 환불 완료 안내";
+        String body = String.format(
+                """
+                안녕하세요!
+
+                %s 대회 관련 환불이 완료되었습니다.
+                환불 금액: %s원
+                """,
+                marathonTitle,
+                amount
+        );
+
+        return new EmailMessage(email, subject, body);
+    }
+}

--- a/backend/src/main/java/com/rungo/api/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/rungo/api/global/config/AsyncConfig.java
@@ -1,19 +1,26 @@
 package com.rungo.api.global.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.concurrent.Executor;
 
+@Slf4j
 @Configuration
 @EnableAsync
-public class AsyncConfig {
+@EnableRetry
+public class AsyncConfig implements AsyncConfigurer {
 
     @Bean(name = "mailExecutor")
     public Executor mailExecutor() {
-
         // 기본 설정 SimpleAsyncTaskExecutor -> Thread 무제한 생성 가능해 OOM 발생 가능
         // 직접 설정하여 OOM 방지(MVP 단계로 최소한으로 생성)
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -21,7 +28,31 @@ public class AsyncConfig {
         executor.setMaxPoolSize(5); // 대기열 꽉 차면 추가로 투입하는 인원
         executor.setQueueCapacity(50); // 작업 대기공간
         executor.setThreadNamePrefix("Mail-Async-"); // 로그 확인용 접두사
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return mailExecutor();
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new LoggingAsyncExceptionHandler();
+    }
+
+    static class LoggingAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+        @Override
+        public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+            log.error(
+                    "비동기 작업 예외 발생: method={}, params={}",
+                    method.getName(),
+                    Arrays.toString(params),
+                    ex
+            );
+        }
     }
 }

--- a/backend/src/main/java/com/rungo/api/global/infrastructure/mail/EmailMessage.java
+++ b/backend/src/main/java/com/rungo/api/global/infrastructure/mail/EmailMessage.java
@@ -1,0 +1,8 @@
+package com.rungo.api.global.infrastructure.mail;
+
+public record EmailMessage(
+        String to,
+        String subject,
+        String body
+) {
+}

--- a/backend/src/main/java/com/rungo/api/global/infrastructure/mail/EmailSenderClient.java
+++ b/backend/src/main/java/com/rungo/api/global/infrastructure/mail/EmailSenderClient.java
@@ -1,0 +1,56 @@
+package com.rungo.api.global.infrastructure.mail;
+
+import com.rungo.api.global.infrastructure.mail.exception.EmailSendException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailSenderClient {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    @Retryable(
+            retryFor = EmailSendException.class,
+            maxAttemptsExpression = "${spring.mail.retry.max-attempts:3}",
+            backoff = @Backoff(
+                    delayExpression = "${spring.mail.retry.delay:1000}",
+                    multiplierExpression = "${spring.mail.retry.multiplier:2.0}"
+            )
+    )
+    public void send(EmailMessage emailMessage) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(emailMessage.to());
+            message.setSubject(emailMessage.subject());
+            message.setText(emailMessage.body());
+            message.setFrom(fromEmail);
+
+            mailSender.send(message);
+
+            log.info("이메일 발송 성공: to={}, subject={}", emailMessage.to(), emailMessage.subject());
+        } catch (MailException ex) {
+            log.warn("이메일 발송 실패 - 재시도 예정: to={}, subject={}",
+                    emailMessage.to(), emailMessage.subject(), ex);
+            throw new EmailSendException("이메일 발송 실패", ex);
+        }
+    }
+
+    @Recover
+    public void recover(EmailSendException ex, EmailMessage emailMessage) {
+        log.error("이메일 최종 발송 실패: to={}, subject={}",
+                emailMessage.to(), emailMessage.subject(), ex);
+    }
+}

--- a/backend/src/main/java/com/rungo/api/global/infrastructure/mail/EmailService.java
+++ b/backend/src/main/java/com/rungo/api/global/infrastructure/mail/EmailService.java
@@ -1,49 +1,19 @@
-package com.rungo.api.global.infrastructure.mail; // 패키지 위치 수정
+package com.rungo.api.global.infrastructure.mail;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
-    private final JavaMailSender mailSender;
+    private final EmailSenderClient mailSenderClient;
 
-    @Value("${spring.mail.username}")
-    private String fromEmail;
+    public void send(EmailMessage emailMessage) {
+        mailSenderClient.send(emailMessage);
+    }
 
-    @Value("${app.mail.enabled:true}")
-    private boolean mailEnabled;
-
-    /*
-     단순 텍스트 이메일 발송
-     @param to 수신자 이메일 주소
-     @param subject 메일 제목
-     @param body 메일 본문
-     */
     public void sendEmail(String to, String subject, String body) {
-        try {
-            if(!mailEnabled){
-                log.info("메일 전송 비활성화 상태 - skip: to={}, subject={}", to, subject);
-                return;
-            }
-            SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(to);
-            message.setSubject(subject);
-            message.setText(body);
-            message.setFrom(fromEmail);
-
-            mailSender.send(message);
-            log.info("이메일 발송 성공: to={}, subject={}", to, subject);
-        } catch (Exception e) {
-            // Stacktrace 전체 로깅
-            // 취소메일인지 접수메일인지 확인
-            log.error("이메일 발송 실패: to={}, subject={}", to, subject, e);
-        }
+        send(new EmailMessage(to, subject, body));
     }
 }

--- a/backend/src/main/java/com/rungo/api/global/infrastructure/mail/exception/EmailSendException.java
+++ b/backend/src/main/java/com/rungo/api/global/infrastructure/mail/exception/EmailSendException.java
@@ -1,0 +1,8 @@
+package com.rungo.api.global.infrastructure.mail.exception;
+
+public class EmailSendException extends RuntimeException {
+
+    public EmailSendException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -30,6 +30,10 @@ spring:
     port: 587
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}
+    retry:
+      max-attempts: 3
+      delay: 1000
+      multiplier: 2.0
     properties:
       mail:
         smtp:

--- a/backend/src/test/java/com/rungo/api/domain/notification/listener/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/notification/listener/NotificationEventListenerTest.java
@@ -2,6 +2,8 @@ package com.rungo.api.domain.notification.listener;
 
 import com.rungo.api.domain.notification.event.MarathonCanceledEvent;
 import com.rungo.api.domain.notification.event.RegistrationCompletedEvent;
+import com.rungo.api.domain.notification.support.NotificationEmailFactory;
+import com.rungo.api.global.infrastructure.mail.EmailMessage;
 import com.rungo.api.global.infrastructure.mail.EmailService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,8 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -23,28 +24,50 @@ class NotificationEventListenerTest {
     @Mock
     private EmailService emailService;
 
+    @Mock
+    private NotificationEmailFactory notificationEmailFactory;
+
     @InjectMocks
     private NotificationEventListener notificationEventListener;
 
     @Test
-    @DisplayName("접수 완료 이벤트 발생 시 이메일 발송 메서드가 호출된다")
+    @DisplayName("접수 완료 이벤트 발생 시 이메일 메시지를 생성하고 발송한다")
     void handleRegistrationCompleted_test() {
-        RegistrationCompletedEvent event = new RegistrationCompletedEvent("test@gmail.com", "서울 마라톤", "10km");
+        RegistrationCompletedEvent event =
+                new RegistrationCompletedEvent("test@gmail.com", "서울 마라톤", "10km");
+
+        EmailMessage message = new EmailMessage(
+                "test@gmail.com",
+                "[Rungo] 서울 마라톤 참가 접수 완료 안내",
+                "body"
+        );
+
+        given(notificationEmailFactory.registrationCompleted(
+                event.email(), event.marathonTitle(), event.courseName())
+        ).willReturn(message);
 
         notificationEventListener.handleRegistrationCompleted(event);
 
-        verify(emailService, times(1)).sendEmail(eq("test@gmail.com"), anyString(), anyString());
+        verify(notificationEmailFactory, times(1))
+                .registrationCompleted(event.email(), event.marathonTitle(), event.courseName());
+        verify(emailService, times(1)).send(message);
     }
 
     @Test
-    @DisplayName("대회 취소 이벤트 발생 시 참가자 수만큼 이메일 발송 메서드가 호출된다")
+    @DisplayName("대회 취소 이벤트 발생 시 참가자 수만큼 이메일 메시지를 생성하고 발송한다")
     void handleMarathonCanceled_test() {
         List<String> emails = List.of("user1@gmail.com", "user2@gmail.com");
         MarathonCanceledEvent event = new MarathonCanceledEvent("서울 마라톤", emails);
 
+        given(notificationEmailFactory.marathonCanceled("user1@gmail.com", "서울 마라톤"))
+                .willReturn(new EmailMessage("user1@gmail.com", "subject1", "body1"));
+        given(notificationEmailFactory.marathonCanceled("user2@gmail.com", "서울 마라톤"))
+                .willReturn(new EmailMessage("user2@gmail.com", "subject2", "body2"));
+
         notificationEventListener.handleMarathonCanceled(event);
 
-        verify(emailService, times(1)).sendEmail(eq("user1@gmail.com"), anyString(), anyString());
-        verify(emailService, times(1)).sendEmail(eq("user2@gmail.com"), anyString(), anyString());
+        verify(notificationEmailFactory, times(1)).marathonCanceled("user1@gmail.com", "서울 마라톤");
+        verify(notificationEmailFactory, times(1)).marathonCanceled("user2@gmail.com", "서울 마라톤");
+        verify(emailService, times(2)).send(org.mockito.ArgumentMatchers.any(EmailMessage.class));
     }
 }

--- a/backend/src/test/java/com/rungo/api/domain/notification/support/NotificationEmailFactoryTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/notification/support/NotificationEmailFactoryTest.java
@@ -1,0 +1,65 @@
+package com.rungo.api.domain.notification.support;
+
+import com.rungo.api.global.infrastructure.mail.EmailMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NotificationEmailFactoryTest {
+
+    private final NotificationEmailFactory factory = new NotificationEmailFactory();
+
+    @Test
+    @DisplayName("접수 완료 메일 메시지를 생성한다")
+    void registrationCompleted_test() {
+        EmailMessage message = factory.registrationCompleted("user@test.com", "서울 마라톤", "10K");
+
+        assertEquals("user@test.com", message.to());
+        assertTrue(message.subject().contains("참가 접수 완료"));
+        assertTrue(message.body().contains("서울 마라톤"));
+        assertTrue(message.body().contains("10K"));
+    }
+
+    @Test
+    @DisplayName("대회 취소 메일 메시지를 생성한다")
+    void marathonCanceled_test() {
+        EmailMessage message = factory.marathonCanceled("user@test.com", "서울 마라톤");
+
+        assertEquals("user@test.com", message.to());
+        assertTrue(message.subject().contains("대회 취소"));
+        assertTrue(message.body().contains("서울 마라톤"));
+    }
+
+    @Test
+    @DisplayName("결제 완료 메일 메시지를 생성한다")
+    void paymentCompleted_test() {
+        EmailMessage message = factory.paymentCompleted(
+                "user@test.com",
+                "서울 마라톤",
+                "10K",
+                BigDecimal.valueOf(60000)
+        );
+
+        assertEquals("user@test.com", message.to());
+        assertTrue(message.subject().contains("결제 완료"));
+        assertTrue(message.body().contains("60000"));
+    }
+
+    @Test
+    @DisplayName("환불 완료 메일 메시지를 생성한다")
+    void refundCompleted_test() {
+        EmailMessage message = factory.refundCompleted(
+                "user@test.com",
+                "서울 마라톤",
+                BigDecimal.valueOf(60000)
+        );
+
+        assertEquals("user@test.com", message.to());
+        assertTrue(message.subject().contains("환불 완료"));
+        assertTrue(message.body().contains("60000"));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #129 

## 🛠️ 작업 내용
- `Spring Retry` 도입
- `Async` 예외 처리기 추가
- `EmailService` 책임 분리
  - `EmailMessage` 객체 추가
  - 실제 발송 전담 클래스(`MailSenderClient`) 분리
  - 예외 처리 및 `retry/recover` 적용
- 알림 메세지 생성 로직 분리
  - 접수 완료
  - 대회 취소
  - 결제 완료 (추후 확장 고려)
  - 환불 완료 (추후 확장 고려)
- `NotificationEventListener` 책임 축소 
- 단위 테스트 수정 및 보강
  - `NotificationEventListener` 테스트 수정 
  - `NotificationEmailFactory` 테스트 추가

## 🎯 리뷰 포인트
- 비동기 이메일 발송 구조가 역할별로 적절히 분리되었는지 확인 부탁드립니다.
- 패키지 구조나 명칭이 적절한지 확인 부탁드립니다.
- `retry / recover` 처리 방식이 적절한지 의견 부탁드립니다.
- 메세지 생성 로직을 팩토리로 분리한 방향이 적절한지 의견 부탁드립니다.
- 추후 결제/환불 이벤트 확장 구조에 적합한지 의견 부탁드립니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?