### PR TITLE
feat: 접수 취소 시 취소 이력 저장 및 예외 처리 추가 (#126)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationCommandService.java
@@ -7,6 +7,8 @@ import com.rungo.api.domain.notification.event.RegistrationCompletedEvent;
 import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
 import com.rungo.api.domain.registration.dto.CreateRegistrationRes;
 import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.entity.RegistrationCancelHistory;
+import com.rungo.api.domain.registration.repository.RegistrationCancelHistoryRepository;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.repository.UserRepository;
@@ -25,6 +27,7 @@ import java.time.LocalDateTime;
 public class RegistrationCommandService {
 
     private final RegistrationRepository registrationRepository;
+    private final RegistrationCancelHistoryRepository registrationCancelHistoryRepository;
     private final CourseRepository courseRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -93,8 +96,8 @@ public class RegistrationCommandService {
         }
 
         Marathon marathon = registration.getMarathon();
-        LocalDateTime now = LocalDateTime.now();
 
+        LocalDateTime now = LocalDateTime.now();
         // 접수 마감 이후에는 취소할 수 없다.
         if (now.isAfter(marathon.getRegistrationEndAt())) {
             throw new CustomException(ErrorCode.REGISTRATION_CANCEL_PERIOD_INVALID);
@@ -103,6 +106,9 @@ public class RegistrationCommandService {
         if (!marathon.isOpen()) {
             throw new CustomException(ErrorCode.MARATHON_NOT_OPEN);
         }
+
+        //유니크 제약을 바로 확인하기 위해 saveAndFlush
+        registrationCancelHistoryRepository.saveAndFlush(RegistrationCancelHistory.create(registration));
 
         courseRepository.decreaseCurrentCountIfPositive(registration.getCourse().getId());
         // 동시성 제어 미적용 메서드

--- a/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/GlobalExceptionHandler.java
@@ -18,6 +18,8 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     private static final String REGISTRATION_DUPLICATE_CONSTRAINT = "uk_registration_user_marathon";
+    private static final String REGISTRATION_CANCEL_HISTORY_DUPLICATE_CONSTRAINT =
+            "uk_registration_cancel_history_original_registration_id";
     private static final String MARATHON_DUPLICATE_CONSTRAINT = "uk_marathon_organizerId_title_eventDate";
 
     // 1. 비즈니스 예외 처리 (CustomException)
@@ -73,7 +75,18 @@ public class GlobalExceptionHandler {
         if (isConstraintViolation(e, REGISTRATION_DUPLICATE_CONSTRAINT)) {
             ErrorCode ec = ErrorCode.REGISTRATION_ALREADY_EXISTS;
 
-            log.warn("Duplicate registration detected. constraintName={}", REGISTRATION_DUPLICATE_CONSTRAINT, e);
+            log.warn("Duplicate registration detected. constraintName={}",
+                    REGISTRATION_DUPLICATE_CONSTRAINT);
+
+            return ResponseEntity.status(ec.getStatus())
+                    .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
+        }
+
+        if (isConstraintViolation(e, REGISTRATION_CANCEL_HISTORY_DUPLICATE_CONSTRAINT)) {
+            ErrorCode ec = ErrorCode.REGISTRATION_ALREADY_CANCELED;
+
+            log.warn("Duplicate registration cancel history detected. constraintName={}",
+                    REGISTRATION_CANCEL_HISTORY_DUPLICATE_CONSTRAINT);
 
             return ResponseEntity.status(ec.getStatus())
                     .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));
@@ -82,7 +95,8 @@ public class GlobalExceptionHandler {
         if (isConstraintViolation(e, MARATHON_DUPLICATE_CONSTRAINT)) {
             ErrorCode ec = ErrorCode.MARATHON_ALREADY_EXISTS;
 
-            log.warn("Duplicate marathon detected. constraintName={}", MARATHON_DUPLICATE_CONSTRAINT, e);
+            log.warn("Duplicate marathon detected. constraintName={}",
+                    MARATHON_DUPLICATE_CONSTRAINT);
 
             return ResponseEntity.status(ec.getStatus())
                     .body(ApiResponse.error(ec.getStatus(), ec.name(), ec.getMessage()));


### PR DESCRIPTION
## 📌 관련 이슈
Closes #126

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 접수 취소 시 `RegistrationCancelHistory`를 저장하도록 서비스 로직 추가
- [x] 취소 이력 저장 후 `Course.currentCount` 감소 및 기존 `Registration` 하드 딜리트 흐름 유지
- [x] 취소 이력 저장 시 유니크 제약 충돌을 `REGISTRATION_ALREADY_CANCELED`로 변환하도록 글로벌 예외 처리 추가


## 🎯 리뷰 포인트
- 접수 취소 흐름이 `취소 이력 저장 -> currentCount 감소 -> registration 삭제` 순서로 가는 것이 적절한지 확인 부탁드립니다!



## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?