### PR TITLE
test: 접수 취소 테스트 보강 및 기존 테스트 수정 (#140)

### DIFF
--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceConcurrencyTest.java
@@ -6,6 +6,8 @@ import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
+import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.repository.RegistrationCancelHistoryRepository;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Gender;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.math.BigDecimal;
@@ -46,6 +49,9 @@ class RegistrationCommandServiceConcurrencyTest {
     private RegistrationRepository registrationRepository;
 
     @Autowired
+    private RegistrationCancelHistoryRepository registrationCancelHistoryRepository;
+
+    @Autowired
     private CourseRepository courseRepository;
 
     @Autowired
@@ -60,6 +66,7 @@ class RegistrationCommandServiceConcurrencyTest {
     @BeforeEach
     @AfterEach
     void clearData() {
+        registrationCancelHistoryRepository.deleteAllInBatch();
         registrationRepository.deleteAllInBatch();
         courseRepository.deleteAllInBatch();
         marathonRepository.deleteAllInBatch();
@@ -157,6 +164,47 @@ class RegistrationCommandServiceConcurrencyTest {
         assertEquals(requestCount, registrationCount);
     }
 
+    @Test
+    @DisplayName("동일 접수를 동시에 취소하면 1건만 성공하고 취소 이력은 1건만 저장된다")
+    void cancel_concurrently_only_one_succeeds() throws Exception {
+        Users participant = saveUser("cancel-participant@test.com", Role.PARTICIPANT);
+        Marathon marathon = saveMarathon("부산 마라톤");
+        Course course = saveCourse(marathon, 10, 1);
+        Registration registration = saveRegistration(participant, course, marathon);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger expectedFailureCount = new AtomicInteger();
+        List<Throwable> unexpectedErrors = new ArrayList<>();
+
+        runConcurrently(2, index -> {
+            try {
+                registrationCommandService.cancel(participant.getId(), registration.getId());
+                successCount.incrementAndGet();
+            } catch (CustomException exception) {
+                if (exception.getErrorCode() == ErrorCode.REGISTRATION_NOT_FOUND) {
+                    expectedFailureCount.incrementAndGet();
+                    return;
+                }
+                synchronized (unexpectedErrors) {
+                    unexpectedErrors.add(exception);
+                }
+            } catch (DataIntegrityViolationException exception) {
+                expectedFailureCount.incrementAndGet();
+            } catch (Throwable throwable) {
+                synchronized (unexpectedErrors) {
+                    unexpectedErrors.add(throwable);
+                }
+            }
+        });
+
+        assertTrue(unexpectedErrors.isEmpty());
+        assertEquals(1, successCount.get());
+        assertEquals(1, expectedFailureCount.get());
+        assertEquals(0, registrationRepository.count());
+        assertEquals(1, registrationCancelHistoryRepository.count());
+        assertEquals(0, findCourse(course.getId()).getCurrentCount());
+    }
+
     private void runConcurrently(int threadCount, ConcurrentAction action) throws Exception {
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch readyLatch = new CountDownLatch(threadCount);
@@ -233,6 +281,12 @@ class RegistrationCommandServiceConcurrencyTest {
 
     private CreateRegistrationReq createRequest(Long courseId) {
         return new CreateRegistrationReq(courseId, "12345", "서울시 강남구", "101동", "L", true);
+    }
+
+    private Registration saveRegistration(Users user, Course course, Marathon marathon) {
+        return registrationRepository.saveAndFlush(
+                Registration.create(user, course, marathon, "12345", "서울시 강남구", "101동", "L", true)
+        );
     }
 
     private Course findCourse(Long courseId) {

--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceTest.java
@@ -8,6 +8,8 @@ import com.rungo.api.domain.notification.event.RegistrationCompletedEvent;
 import com.rungo.api.domain.registration.dto.CreateRegistrationReq;
 import com.rungo.api.domain.registration.dto.CreateRegistrationRes;
 import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.entity.RegistrationCancelHistory;
+import com.rungo.api.domain.registration.repository.RegistrationCancelHistoryRepository;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Gender;
@@ -47,6 +49,9 @@ class RegistrationCommandServiceTest {
 
     @Mock
     private RegistrationRepository registrationRepository;
+
+    @Mock
+    private RegistrationCancelHistoryRepository registrationCancelHistoryRepository;
 
     @Mock
     private CourseRepository courseRepository;
@@ -294,6 +299,7 @@ class RegistrationCommandServiceTest {
 
         registrationCommandService.cancel(1L, 1L);
 
+        verify(registrationCancelHistoryRepository, times(1)).saveAndFlush(any(RegistrationCancelHistory.class));
         verify(courseRepository, times(1)).decreaseCurrentCountIfPositive(3L);
         verify(registrationRepository, times(1)).delete(registration);
     }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #140

## 🛠️ 작업 내용
- [x] 기존 `접수 취소 성공` 테스트가 현재 서비스 구조에 맞게 동작하도록 수정
- [x] 동일 접수에 대한 취소 동시성 테스트 시나리오 추가

## 🎯 리뷰 포인트
추가해야할 테스트 케이스 있는지 확인부탁드립니다!


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?