### PR TITLE
refactor: 주최자 접수 현황 로직 분리 (#136)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationOrganizerQueryController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationOrganizerQueryController.java
@@ -1,11 +1,9 @@
 package com.rungo.api.domain.registration.controller;
 
-import com.rungo.api.domain.registration.dto.MyRegistrationRes;
 import com.rungo.api.domain.registration.dto.RegistrationOverviewRes;
 import com.rungo.api.domain.registration.dto.RegistrationParticipantDetailRes;
 import com.rungo.api.domain.registration.dto.RegistrationParticipantListRes;
-import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
-import com.rungo.api.domain.registration.service.RegistrationReadService;
+import com.rungo.api.domain.registration.service.RegistrationOrganizerQueryService;
 import com.rungo.api.global.response.ApiResponse;
 import com.rungo.api.global.security.SecurityUser;
 import jakarta.validation.constraints.Max;
@@ -25,26 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequiredArgsConstructor
-public class RegistrationsReadController {
+public class RegistrationOrganizerQueryController {
 
-    private final RegistrationReadService registrationReadService;
-
-    // 인증된 사용자의 접수 목록 조회
-    @GetMapping("/api/v1/registrations/me")
-    public ResponseEntity<ApiResponse<MyRegistrationRes>> getMyRegistrations(
-            @AuthenticationPrincipal SecurityUser user,
-            @RequestParam(required = false) RegistrationStatus status,
-            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
-            @RequestParam(defaultValue = "20") @Min(value = 1, message = "size는 1 이상이어야 합니다.")
-            @Max(value = 100, message = "size는 100 이하여야 합니다.") int size
-    ) {
-        // 신청일 기준 최신순 정렬
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("appliedAt"), Sort.Order.desc("id")));
-
-        MyRegistrationRes result = registrationReadService.getMyRegistrations(user.getId(), status, pageable);
-
-        return ResponseEntity.ok(ApiResponse.ok(result));
-    }
+    private final RegistrationOrganizerQueryService registrationOrganizerQueryService;
 
     // 주최자 - 접수 요약 조회
     @GetMapping("/api/v1/organizer/marathons/{id}/registrations/summary")
@@ -52,7 +33,7 @@ public class RegistrationsReadController {
             @AuthenticationPrincipal SecurityUser organizer,
             @PathVariable("id") Long marathonId
     ) {
-        RegistrationOverviewRes result = registrationReadService.getRegistrationOverview(
+        RegistrationOverviewRes result = registrationOrganizerQueryService.getRegistrationOverview(
                 organizer.getId(), marathonId
         );
 
@@ -73,7 +54,7 @@ public class RegistrationsReadController {
         // 신청일 최신순, 같은 신청일이면 id 역순으로 고정
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("appliedAt"), Sort.Order.desc("id")));
 
-        RegistrationParticipantListRes result = registrationReadService.getMarathonParticipants(
+        RegistrationParticipantListRes result = registrationOrganizerQueryService.getMarathonParticipants(
                 organizer.getId(), marathonId, courseId, name, pageable
         );
 
@@ -87,7 +68,7 @@ public class RegistrationsReadController {
             @PathVariable Long marathonId,
             @PathVariable Long registrationId
     ) {
-        RegistrationParticipantDetailRes result = registrationReadService.getMarathonParticipantDetail(
+        RegistrationParticipantDetailRes result = registrationOrganizerQueryService.getMarathonParticipantDetail(
                 organizer.getId(), marathonId, registrationId
         );
 

--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationOrganizerQueryController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationOrganizerQueryController.java
@@ -15,20 +15,18 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Validated
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/organizer/marathons/{id}/registrations")
 public class RegistrationOrganizerQueryController {
 
     private final RegistrationOrganizerQueryService registrationOrganizerQueryService;
 
     // 주최자 - 접수 요약 조회
-    @GetMapping("/api/v1/organizer/marathons/{id}/registrations/summary")
+    @GetMapping("/summary")
     public ResponseEntity<ApiResponse<RegistrationOverviewRes>> getRegistrationOverview(
             @AuthenticationPrincipal SecurityUser organizer,
             @PathVariable("id") Long marathonId
@@ -41,7 +39,7 @@ public class RegistrationOrganizerQueryController {
     }
 
     // 주최자 - 참가자 목록 조회
-    @GetMapping("/api/v1/organizer/marathons/{id}/registrations")
+    @GetMapping()
     public ResponseEntity<ApiResponse<RegistrationParticipantListRes>> getMarathonParticipants(
             @AuthenticationPrincipal SecurityUser organizer,
             @PathVariable("id") Long marathonId,
@@ -62,10 +60,10 @@ public class RegistrationOrganizerQueryController {
     }
 
     // 주최자 - 참가자 상세 조회
-    @GetMapping("/api/v1/organizer/marathons/{marathonId}/registrations/{registrationId}")
+    @GetMapping("/{registrationId}")
     public ResponseEntity<ApiResponse<RegistrationParticipantDetailRes>> getMarathonParticipantDetail(
             @AuthenticationPrincipal SecurityUser organizer,
-            @PathVariable Long marathonId,
+            @PathVariable("id") Long marathonId,
             @PathVariable Long registrationId
     ) {
         RegistrationParticipantDetailRes result = registrationOrganizerQueryService.getMarathonParticipantDetail(

--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationReadController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationReadController.java
@@ -1,0 +1,45 @@
+package com.rungo.api.domain.registration.controller;
+
+import com.rungo.api.domain.registration.dto.MyRegistrationRes;
+import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
+import com.rungo.api.domain.registration.service.RegistrationReadService;
+import com.rungo.api.global.response.ApiResponse;
+import com.rungo.api.global.security.SecurityUser;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class RegistrationReadController {
+
+    private final RegistrationReadService registrationReadService;
+
+    // 인증된 사용자의 접수 목록 조회
+    @GetMapping("/api/v1/registrations/me")
+    public ResponseEntity<ApiResponse<MyRegistrationRes>> getMyRegistrations(
+            @AuthenticationPrincipal SecurityUser user,
+            @RequestParam(required = false) RegistrationStatus status,
+            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "20") @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+            @Max(value = 100, message = "size는 100 이하여야 합니다.") int size
+    ) {
+        // 신청일 기준 최신순 정렬
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("appliedAt"), Sort.Order.desc("id")));
+
+        MyRegistrationRes result = registrationReadService.getMyRegistrations(user.getId(), status, pageable);
+
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+}

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationOrganizerQueryService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationOrganizerQueryService.java
@@ -1,0 +1,114 @@
+package com.rungo.api.domain.registration.service;
+
+import com.rungo.api.domain.marathon.course.entity.Course;
+import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
+import com.rungo.api.domain.registration.dto.RegistrationOverviewRes;
+import com.rungo.api.domain.registration.dto.RegistrationParticipantDetailRes;
+import com.rungo.api.domain.registration.dto.RegistrationParticipantListRes;
+import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.repository.RegistrationRepository;
+import com.rungo.api.global.exception.CustomException;
+import com.rungo.api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationOrganizerQueryService {
+
+    private final RegistrationRepository registrationRepository;
+    private final MarathonRepository marathonRepository;
+    private final CourseRepository courseRepository;
+
+    // 주최자 - 접수 요약 조회
+    @Transactional(readOnly = true)
+    public RegistrationOverviewRes getRegistrationOverview(Long organizerId, Long marathonId) {
+
+        Marathon marathon = getMarathonById(marathonId);
+        validateOrganizer(marathon, organizerId);
+
+        // 해당 마라톤의 코스 목록 조회
+        List<Course> courses = courseRepository.findAllByMarathon_IdOrderByIdAsc(marathonId);
+
+        return RegistrationOverviewRes.of(marathon, courses);
+    }
+
+    // 주최자 - 참가자 목록 조회
+    @Transactional(readOnly = true)
+    public RegistrationParticipantListRes getMarathonParticipants(
+            Long organizerId,
+            Long marathonId,
+            Long courseId,
+            String name,
+            Pageable pageable
+    ) {
+
+        Marathon marathon = getMarathonById(marathonId);
+        validateOrganizer(marathon, organizerId);
+
+        String keyword = normalizeKeyword(name);
+
+        Page<Registration> page;
+
+        // 필터 조합에 따라 참가자 목록 조회
+        if (courseId == null && keyword == null) {
+            page = registrationRepository.findByMarathon_Id(marathonId, pageable);
+        } else if (courseId != null && keyword == null) {
+            page = registrationRepository.findByMarathon_IdAndCourse_Id(marathonId, courseId, pageable);
+        } else if (courseId == null) {
+            page = registrationRepository.findByMarathon_IdAndSnapNameContaining(marathonId, keyword, pageable);
+        } else {
+            page = registrationRepository.findByMarathon_IdAndCourse_IdAndSnapNameContaining(
+                    marathonId, courseId, keyword, pageable
+            );
+        }
+
+        return RegistrationParticipantListRes.from(page);
+    }
+
+    // 주최자 - 참가자 상세 조회
+    @Transactional(readOnly = true)
+    public RegistrationParticipantDetailRes getMarathonParticipantDetail(
+            Long organizerId,
+            Long marathonId,
+            Long registrationId
+    ) {
+
+        Marathon marathon = getMarathonById(marathonId);
+        validateOrganizer(marathon, organizerId);
+
+        // 접수 여부 검증
+        Registration registration = registrationRepository.findByIdAndMarathon_Id(registrationId, marathonId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REGISTRATION_NOT_FOUND));
+
+        return RegistrationParticipantDetailRes.from(registration);
+    }
+
+    // 마라톤 존재 여부 검증
+    private Marathon getMarathonById(Long marathonId) {
+        return marathonRepository.findById(marathonId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
+    }
+
+    // 주최자 일치 여부 검증
+    private void validateOrganizer(Marathon marathon, Long organizerId) {
+        if (!marathon.getOrganizer().getId().equals(organizerId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+    // 검색 이름 정리 -> null/blank는 검색 조건 없음으로 간주, 공백 검색 방지
+    private String normalizeKeyword(String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return name.trim();
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationOrganizerQueryService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationOrganizerQueryService.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RegistrationOrganizerQueryService {
 
     private final RegistrationRepository registrationRepository;
@@ -28,7 +29,6 @@ public class RegistrationOrganizerQueryService {
     private final CourseRepository courseRepository;
 
     // 주최자 - 접수 요약 조회
-    @Transactional(readOnly = true)
     public RegistrationOverviewRes getRegistrationOverview(Long organizerId, Long marathonId) {
 
         Marathon marathon = getMarathonById(marathonId);
@@ -41,7 +41,6 @@ public class RegistrationOrganizerQueryService {
     }
 
     // 주최자 - 참가자 목록 조회
-    @Transactional(readOnly = true)
     public RegistrationParticipantListRes getMarathonParticipants(
             Long organizerId,
             Long marathonId,
@@ -74,7 +73,6 @@ public class RegistrationOrganizerQueryService {
     }
 
     // 주최자 - 참가자 상세 조회
-    @Transactional(readOnly = true)
     public RegistrationParticipantDetailRes getMarathonParticipantDetail(
             Long organizerId,
             Long marathonId,

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
@@ -1,33 +1,20 @@
 package com.rungo.api.domain.registration.service;
 
-import com.rungo.api.domain.marathon.course.entity.Course;
-import com.rungo.api.domain.marathon.course.repository.CourseRepository;
-import com.rungo.api.domain.marathon.marathon.entity.Marathon;
-import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
-import com.rungo.api.domain.registration.dto.RegistrationOverviewRes;
-import com.rungo.api.domain.registration.dto.RegistrationParticipantDetailRes;
-import com.rungo.api.domain.registration.dto.RegistrationParticipantListRes;
 import com.rungo.api.domain.registration.entity.Registration;
 import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
-import com.rungo.api.global.exception.CustomException;
-import com.rungo.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class RegistrationReadService {
 
     private final RegistrationRepository registrationRepository;
-    private final MarathonRepository marathonRepository;
-    private final CourseRepository courseRepository;
 
     // 내 접수 목록 조회
     @Transactional(readOnly = true)
@@ -45,89 +32,5 @@ public class RegistrationReadService {
         return MyRegistrationRes.from(page);
     }
 
-    // 주최자 - 접수 요약 조회
-    @Transactional(readOnly = true)
-    public RegistrationOverviewRes getRegistrationOverview(Long organizerId, Long marathonId) {
-
-        Marathon marathon = getMarathonById(marathonId);
-        validateOrganizer(marathon, organizerId);
-
-        // 해당 마라톤의 코스 목록 조회
-        List<Course> courses = courseRepository.findAllByMarathon_IdOrderByIdAsc(marathonId);
-
-        return RegistrationOverviewRes.of(marathon, courses);
-    }
-
-    // 주최자 - 참가자 목록 조회
-    @Transactional(readOnly = true)
-    public RegistrationParticipantListRes getMarathonParticipants(
-            Long organizerId,
-            Long marathonId,
-            Long courseId,
-            String name,
-            Pageable pageable
-    ) {
-
-        Marathon marathon = getMarathonById(marathonId);
-        validateOrganizer(marathon, organizerId);
-
-        String keyword = normalizeKeyword(name);
-
-        Page<Registration> page;
-
-        // 필터 조합에 따라 참가자 목록 조회
-        if (courseId == null && keyword == null) {
-            page = registrationRepository.findByMarathon_Id(marathonId, pageable);
-        } else if (courseId != null && keyword == null) {
-            page = registrationRepository.findByMarathon_IdAndCourse_Id(marathonId, courseId, pageable);
-        } else if (courseId == null) {
-            page = registrationRepository.findByMarathon_IdAndSnapNameContaining(marathonId, keyword, pageable);
-        } else {
-            page = registrationRepository.findByMarathon_IdAndCourse_IdAndSnapNameContaining(
-                    marathonId, courseId, keyword, pageable
-            );
-        }
-
-        return RegistrationParticipantListRes.from(page);
-    }
-
-    // 주최자 - 참가자 상세 조회
-    @Transactional(readOnly = true)
-    public RegistrationParticipantDetailRes getMarathonParticipantDetail(
-            Long organizerId,
-            Long marathonId,
-            Long registrationId
-    ) {
-
-        Marathon marathon = getMarathonById(marathonId);
-        validateOrganizer(marathon, organizerId);
-
-        // 접수 여부 검증
-        Registration registration = registrationRepository.findByIdAndMarathon_Id(registrationId, marathonId)
-                .orElseThrow(() -> new CustomException(ErrorCode.REGISTRATION_NOT_FOUND));
-
-        return RegistrationParticipantDetailRes.from(registration);
-    }
-
-    // 마라톤 존재 여부 검증
-    private Marathon getMarathonById(Long marathonId) {
-        return marathonRepository.findById(marathonId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MARATHON_NOT_FOUND));
-    }
-
-    // 주최자 일치 여부 검증
-    private void validateOrganizer(Marathon marathon, Long organizerId) {
-        if (!marathon.getOrganizer().getId().equals(organizerId)) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-    }
-
-    // 검색 이름 정리 -> null/blank는 검색 조건 없음으로 간주, 공백 검색 방지
-    private String normalizeKeyword(String name) {
-        if (name == null || name.isBlank()) {
-            return null;
-        }
-        return name.trim();
-    }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #136 

## 🛠️ 작업 내용


- [x] `RegistrationsReadController` -> `RegistrationReadController` 오타 수정
- [x] `RegistrationReadService` 에서 주최자 접수 현황 로직을 `RegistrationOrganizerQueryService`로 이동
- [x] `RegistrationReadController`에서 주최자 접수 현황 로직을 `RegistrationOrganizerQueryController`로 이동


## 🎯 리뷰 포인트
- 단순히 클래스를 나눠 역할 분리를 진행하였습니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?