### PR TITLE
feat: 접수 취소 사유 필드 추가 (#146)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/entity/RegistrationCancelHistory.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/entity/RegistrationCancelHistory.java
@@ -1,8 +1,11 @@
 package com.rungo.api.domain.registration.entity;
 
+import com.rungo.api.domain.registration.enumtype.RegistrationCancelReason;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -71,6 +74,10 @@ public class RegistrationCancelHistory {
     @Column(name = "applied_at", nullable = false)
     private LocalDateTime appliedAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cancel_reason", nullable = false)
+    private RegistrationCancelReason cancelReason;
+
     @CreatedDate
     @Column(name = "canceled_at", nullable = false)
     private LocalDateTime canceledAt;
@@ -87,7 +94,8 @@ public class RegistrationCancelHistory {
             String snapDetail,
             String tSize,
             boolean agreedTerms,
-            LocalDateTime appliedAt
+            LocalDateTime appliedAt,
+            RegistrationCancelReason cancelReason
     ) {
         this.originalRegistrationId = originalRegistrationId;
         this.userId = userId;
@@ -101,9 +109,17 @@ public class RegistrationCancelHistory {
         this.tSize = tSize;
         this.agreedTerms = agreedTerms;
         this.appliedAt = appliedAt;
+        this.cancelReason = cancelReason;
     }
 
     public static RegistrationCancelHistory create(Registration registration) {
+        return create(registration, RegistrationCancelReason.USER_CANCELED);
+    }
+
+    public static RegistrationCancelHistory create(
+            Registration registration,
+            RegistrationCancelReason cancelReason
+    ) {
         return new RegistrationCancelHistory(
                 registration.getId(),
                 registration.getUser().getId(),
@@ -116,7 +132,8 @@ public class RegistrationCancelHistory {
                 registration.getSnapDetail(),
                 registration.getTSize(),
                 registration.isAgreedTerms(),
-                registration.getAppliedAt()
+                registration.getAppliedAt(),
+                cancelReason
         );
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/enumtype/RegistrationCancelReason.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/enumtype/RegistrationCancelReason.java
@@ -1,0 +1,6 @@
+package com.rungo.api.domain.registration.enumtype;
+
+public enum RegistrationCancelReason {
+    USER_CANCELED,
+    MARATHON_CANCELED
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #146

## 🛠️ 작업 내용
- [x] `RegistrationCancelReason` enum 추가
- [x] `RegistrationCancelHistory`에 `cancelReason` 필드 추가

## 🎯 리뷰 포인트
- 현재 PR은 최소 수정 범위로 `enum`과 엔티티 필드만 추가했습니다.
- 대회 취소 시 `MARATHON_CANCELED`를 사용하는 로직은 후속 작업에서 연결 예정입니다.
- 기존 개인 접수 취소 흐름이 깨지지 않도록 기본 생성 메서드는 `USER_CANCELED`를 사용하게 유지했습니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?