### PR TITLE
feat: 대회 취소 시 접수 이력 이동 및 활성 접수 삭제 (#153)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/course/entity/Course.java
@@ -60,6 +60,10 @@ public class Course {
         }
     }
 
+    public void resetCurrentCount() {
+        this.currentCount = 0;
+    }
+
     public Integer getRemainingCount(){
         return this.capacity - this.currentCount;
     }

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -13,6 +13,10 @@ import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.marathon.marathon.enumtype.MarathonStatus;
 import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.notification.event.MarathonCanceledEvent;
+import com.rungo.api.domain.registration.entity.Registration;
+import com.rungo.api.domain.registration.entity.RegistrationCancelHistory;
+import com.rungo.api.domain.registration.enumtype.RegistrationCancelReason;
+import com.rungo.api.domain.registration.repository.RegistrationCancelHistoryRepository;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Role;
@@ -42,6 +46,7 @@ public class MarathonService {
     private final MarathonRepository marathonRepository;
     private final UserRepository userRepository;
     private final RegistrationRepository registrationRepository;
+    private final RegistrationCancelHistoryRepository registrationCancelHistoryRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Value("${marathon.min-days.start-to-end}")
@@ -152,8 +157,23 @@ public class MarathonService {
         // 참가자 이메일 미리 조회 (N+1 방지용 JPQL 활용)
         List<String> participantEmails =
                 registrationRepository.findParticipantEmailsByMarathonId(marathonId);
+        List<Registration> registrations =
+                registrationRepository.findAllByMarathon_IdOrderByAppliedAtDesc(marathonId);
 
         marathon.cancel();
+        if (!registrations.isEmpty()) {
+            List<RegistrationCancelHistory> cancelHistories = registrations.stream()
+                    .map(registration -> RegistrationCancelHistory.create(
+                            registration,
+                            RegistrationCancelReason.MARATHON_CANCELED
+                    ))
+                    .toList();
+
+            registrationCancelHistoryRepository.saveAll(cancelHistories);
+            registrationRepository.deleteAll(registrations);
+        }
+
+        marathon.getCourses().forEach(Course::resetCurrentCount);
 
         // 참가자 있을 경우만 이벤트 발행
         if (!participantEmails.isEmpty()) {


### PR DESCRIPTION
## 📌 관련 이슈
Closes #153
## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 활성 접수를 `RegistrationCancelHistory`로 이동하고 `cancelReason`을 `MARATHON_CANCELED`로 저장하도록 구현
- [x] 이동 후 기존 활성 접수를 삭제하도록 처리
- [x] 대회 취소 후 코스 `currentCount`를 `0`으로 초기화하도록 반영



## 🎯 리뷰 포인트
-  취소된 대회의 코스 `currentCount`를 `0`으로 초기화 방식으로 반영했습니다. 의견 부탁드립니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?