### PR TITLE
feat: 접수 완료 응답에 대회명과 코스타입 추가 (#159)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/dto/CreateRegistrationRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/dto/CreateRegistrationRes.java
@@ -7,7 +7,9 @@ import java.time.LocalDateTime;
 public record CreateRegistrationRes(
         Long registrationId,
         Long marathonId,
+        String marathonTitle,
         Long courseId,
+        String courseType,
         String status,
         LocalDateTime appliedAt
 
@@ -16,7 +18,9 @@ public record CreateRegistrationRes(
         return new CreateRegistrationRes(
                 registration.getId(),
                 registration.getMarathon().getId(),
+                registration.getMarathon().getTitle(),
                 registration.getCourse().getId(),
+                registration.getCourse().getCourseType(),
                 registration.getStatus().name(),
                 registration.getAppliedAt()
         );

--- a/backend/src/test/java/com/rungo/api/domain/registration/controller/RegistrationCommandControllerTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/controller/RegistrationCommandControllerTest.java
@@ -62,7 +62,9 @@ class RegistrationCommandControllerTest {
         CreateRegistrationRes response = new CreateRegistrationRes(
                 10L,
                 20L,
+                "서울 마라톤",
                 1L,
+                "10K",
                 "COMPLETED",
                 LocalDateTime.of(2026, 4, 16, 9, 0)
         );
@@ -78,7 +80,9 @@ class RegistrationCommandControllerTest {
                 .andExpect(jsonPath("$.message").value("접수가 완료되었습니다."))
                 .andExpect(jsonPath("$.data.registrationId").value(10))
                 .andExpect(jsonPath("$.data.marathonId").value(20))
+                .andExpect(jsonPath("$.data.marathonTitle").value("서울 마라톤"))
                 .andExpect(jsonPath("$.data.courseId").value(1))
+                .andExpect(jsonPath("$.data.courseType").value("10K"))
                 .andExpect(jsonPath("$.data.status").value("COMPLETED"));
 
         verify(registrationCommandService).create(eq(1L), eq(request));

--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceIntegrationTest.java
@@ -81,6 +81,8 @@ class RegistrationCommandServiceIntegrationTest {
 
         assertThat(res).isNotNull();
         assertThat(res.registrationId()).isNotNull();
+        assertThat(res.marathonTitle()).isEqualTo("서울 마라톤");
+        assertThat(res.courseType()).isEqualTo("10K");
         assertThat(registrationRepository.findById(res.registrationId())).isPresent();
 
         Course savedCourse = courseRepository.findById(course.getId()).orElseThrow();

--- a/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceTest.java
+++ b/backend/src/test/java/com/rungo/api/domain/registration/service/RegistrationCommandServiceTest.java
@@ -117,7 +117,9 @@ class RegistrationCommandServiceTest {
         assertNotNull(result);
         assertEquals(4L, result.registrationId());
         assertEquals(2L, result.marathonId());
+        assertEquals("서울 마라톤", result.marathonTitle());
         assertEquals(3L, result.courseId());
+        assertEquals("10K", result.courseType());
         assertEquals("COMPLETED", result.status());
         assertEquals(appliedAt, result.appliedAt());
 


### PR DESCRIPTION
## 📌 관련 이슈
Closes #159

## 🛠️ 작업 내용
- [x] 접수 완료 응답 DTO에 `marathonTitle`, `courseType` 필드 추가
- [x] 컨트롤러/서비스 단위 테스트와 통합 테스트에 신규 응답 필드 검증 추가


## 🎯 리뷰 포인트
- 접수 완료 직후 사용자가 신청한 대회와 코스를 바로 확인할 수 있도록 표시용 필드를 응답에 추가했습니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?