### PR TITLE
feat: 접수 조회 API에서 상태 필터링 기능 추가, 취소된 접수 이력 조회 기능 추가 (#154)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationReadController.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/controller/RegistrationReadController.java
@@ -1,7 +1,7 @@
 package com.rungo.api.domain.registration.controller;
 
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
-import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
+import com.rungo.api.domain.registration.enumtype.MyRegistrationStatusFilter;
 import com.rungo.api.domain.registration.service.RegistrationReadService;
 import com.rungo.api.global.response.ApiResponse;
 import com.rungo.api.global.security.SecurityUser;
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -25,17 +24,18 @@ public class RegistrationReadController {
 
     private final RegistrationReadService registrationReadService;
 
-    // 인증된 사용자의 접수 목록 조회
     @GetMapping("/api/v1/registrations/me")
     public ResponseEntity<ApiResponse<MyRegistrationRes>> getMyRegistrations(
             @AuthenticationPrincipal SecurityUser user,
-            @RequestParam(required = false) RegistrationStatus status,
-            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
-            @RequestParam(defaultValue = "20") @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+            @RequestParam(defaultValue = "ACTIVE") MyRegistrationStatusFilter status,
+            @RequestParam(defaultValue = "0")
+            @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "20")
+            @Min(value = 1, message = "size는 1 이상이어야 합니다.")
             @Max(value = 100, message = "size는 100 이하여야 합니다.") int size
     ) {
-        // 신청일 기준 최신순 정렬
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("appliedAt"), Sort.Order.desc("id")));
+
+        Pageable pageable = PageRequest.of(page, size);
 
         MyRegistrationRes result = registrationReadService.getMyRegistrations(user.getId(), status, pageable);
 

--- a/backend/src/main/java/com/rungo/api/domain/registration/dto/MyRegistrationRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/dto/MyRegistrationRes.java
@@ -1,36 +1,61 @@
 package com.rungo.api.domain.registration.dto;
 
 
+import com.rungo.api.domain.marathon.course.entity.Course;
 import com.rungo.api.domain.marathon.marathon.dto.PageRes;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
 import com.rungo.api.domain.registration.entity.Registration;
-import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
+import com.rungo.api.domain.registration.entity.RegistrationCancelHistory;
 import org.springframework.data.domain.Page;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public record MyRegistrationRes(
         List<Item> content,
         PageRes pageRes
 ) {
-    public static MyRegistrationRes from(Page<Registration> page) {
+
+    // 정상 접수 목록 DTO 변환
+    public static MyRegistrationRes fromActive(Page<Registration> page) {
         return new MyRegistrationRes(
                 page.getContent().stream()
-                        .map(Item::from)
+                        .map(Item::fromActive)
                         .toList(),
                 PageRes.from(page)
         );
     }
 
+    // 접수 취소 목록 DTO 변환
+    public static MyRegistrationRes fromCanceled(
+            Page<RegistrationCancelHistory> page,
+            Map<Long, Marathon> marathonMap,
+            Map<Long, Course> courseMap
+    ) {
+        return new MyRegistrationRes(
+                page.getContent().stream()
+                        .map(history -> Item.fromCanceled(
+                                history,
+                                marathonMap.get(history.getMarathonId()),
+                                courseMap.get(history.getCourseId())
+                        ))
+                        .toList(),
+                PageRes.from(page)
+        );
+    }
+
+    // ACTIVE, CANCELED 공통 구조 => 일부 필드는 null
     public record Item(
             Long registrationId,
+            Long historyId,
             Long marathonId,
             String marathonTitle,
             Long courseId,
             String courseType,
-            RegistrationStatus status,
+            String status,
             BigDecimal price,
             LocalDate eventDate,
 
@@ -39,19 +64,22 @@ public record MyRegistrationRes(
             String snapZipCode,
             String snapAddress,
             String snapDetail,
-
             String tSize,
-            boolean agreedTerms,
-            LocalDateTime appliedAt
+            Boolean agreedTerms,
+
+            LocalDateTime appliedAt,
+            LocalDateTime canceledAt
     ) {
-        public static Item from(Registration registration) {
+        // 정상 접수 Entity를 응답용 item 변환 (취소 전용 필드는 null : originalRegistrationId, canceledAt)
+        public static Item fromActive(Registration registration) {
             return new Item(
                     registration.getId(),
+                    null,
                     registration.getMarathon().getId(),
                     registration.getMarathon().getTitle(),
                     registration.getCourse().getId(),
                     registration.getCourse().getCourseType(),
-                    registration.getStatus(),
+                    "ACTIVE",
                     registration.getCourse().getPrice(),
                     registration.getMarathon().getEventDate(),
 
@@ -60,10 +88,41 @@ public record MyRegistrationRes(
                     registration.getSnapZipCode(),
                     registration.getSnapAddress(),
                     registration.getSnapDetail(),
-
                     registration.getTSize(),
                     registration.isAgreedTerms(),
-                    registration.getAppliedAt()
+
+                    registration.getAppliedAt(),
+                    null
+            );
+        }
+
+        // 취소 접수 Entity를 응답용 item 변환
+        public static Item fromCanceled(
+                RegistrationCancelHistory history,
+                Marathon marathon,
+                Course course
+        ) {
+            return new Item(
+                    history.getId(),
+                    history.getOriginalRegistrationId(),
+                    history.getMarathonId(),
+                    marathon != null ? marathon.getTitle() : null,
+                    history.getCourseId(),
+                    course != null ? course.getCourseType() : null,
+                    "CANCELED",
+                    course != null ? course.getPrice() : null,
+                    marathon != null ? marathon.getEventDate() : null,
+
+                    history.getSnapName(),
+                    history.getSnapPhoneNumber(),
+                    history.getSnapZipCode(),
+                    history.getSnapAddress(),
+                    history.getSnapDetail(),
+                    history.getTSize(),
+                    history.isAgreedTerms(),
+
+                    history.getAppliedAt(),
+                    history.getCanceledAt()
             );
         }
     }

--- a/backend/src/main/java/com/rungo/api/domain/registration/enumtype/MyRegistrationStatusFilter.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/enumtype/MyRegistrationStatusFilter.java
@@ -1,0 +1,6 @@
+package com.rungo.api.domain.registration.enumtype;
+
+public enum MyRegistrationStatusFilter {
+    ACTIVE,
+    CANCELED
+}

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationCancelHistoryRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationCancelHistoryRepository.java
@@ -1,7 +1,10 @@
 package com.rungo.api.domain.registration.repository;
 
 import com.rungo.api.domain.registration.entity.RegistrationCancelHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegistrationCancelHistoryRepository extends JpaRepository<RegistrationCancelHistory, Long> {
+    Page<RegistrationCancelHistory> findByUserId(Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -17,9 +17,9 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
 
 //    @EntityGraph(attributePaths = {"marathon", "course"})
 //    Page<Registration> findByUser_IdAndStatus(Long userId, RegistrationStatus status, Pageable pageable);
-//
-//    @EntityGraph(attributePaths = {"user", "course"})
-//    List<Registration> findAllByMarathon_IdOrderByAppliedAtDesc(Long marathonId);
+
+    @EntityGraph(attributePaths = {"user", "course"})
+    List<Registration> findAllByMarathon_IdOrderByAppliedAtDesc(Long marathonId);
 
     @EntityGraph(attributePaths = {"course"})
     Page<Registration> findByMarathon_Id(Long marathonId, Pageable pageable);

--- a/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/repository/RegistrationRepository.java
@@ -3,9 +3,6 @@ package com.rungo.api.domain.registration.repository;
 import com.rungo.api.domain.registration.entity.Registration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,11 +15,11 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     @EntityGraph(attributePaths = {"marathon", "course"})
     Page<Registration> findByUser_Id(Long userId, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"marathon", "course"})
-    Page<Registration> findByUser_IdAndStatus(Long userId, RegistrationStatus status, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"user", "course"})
-    List<Registration> findAllByMarathon_IdOrderByAppliedAtDesc(Long marathonId);
+//    @EntityGraph(attributePaths = {"marathon", "course"})
+//    Page<Registration> findByUser_IdAndStatus(Long userId, RegistrationStatus status, Pageable pageable);
+//
+//    @EntityGraph(attributePaths = {"user", "course"})
+//    List<Registration> findAllByMarathon_IdOrderByAppliedAtDesc(Long marathonId);
 
     @EntityGraph(attributePaths = {"course"})
     Page<Registration> findByMarathon_Id(Long marathonId, Pageable pageable);

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationReadService.java
@@ -1,36 +1,104 @@
 package com.rungo.api.domain.registration.service;
 
+import com.rungo.api.domain.marathon.course.entity.Course;
+import com.rungo.api.domain.marathon.course.repository.CourseRepository;
+import com.rungo.api.domain.marathon.marathon.entity.Marathon;
+import com.rungo.api.domain.marathon.marathon.repository.MarathonRepository;
 import com.rungo.api.domain.registration.dto.MyRegistrationRes;
 import com.rungo.api.domain.registration.entity.Registration;
-import com.rungo.api.domain.registration.enumtype.RegistrationStatus;
+import com.rungo.api.domain.registration.entity.RegistrationCancelHistory;
+import com.rungo.api.domain.registration.enumtype.MyRegistrationStatusFilter;
+import com.rungo.api.domain.registration.repository.RegistrationCancelHistoryRepository;
 import com.rungo.api.domain.registration.repository.RegistrationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RegistrationReadService {
 
     private final RegistrationRepository registrationRepository;
+    private final RegistrationCancelHistoryRepository registrationCancelHistoryRepository;
+    private final MarathonRepository marathonRepository;
+    private final CourseRepository courseRepository;
 
-    // 내 접수 목록 조회
+    // status 필터에 따른 내 접수 목록 조회
+    // ACTIVE   : 정상 접수인 상태 (취소 되지 않은 모든 접수)
+    // CANCELED : 취소된 접수 상태
     @Transactional(readOnly = true)
-    public MyRegistrationRes getMyRegistrations(Long userId, RegistrationStatus status, Pageable pageable) {
+    public MyRegistrationRes getMyRegistrations(Long userId, MyRegistrationStatusFilter status, Pageable pageable) {
 
-        Page<Registration> page;
-
-        // 상태 필터 없을 시 전체 목록 조회, 있을 시 해당 상태의 목록만 조회
-        if (status == null) {
-            page = registrationRepository.findByUser_Id(userId, pageable);
-        } else {
-            page = registrationRepository.findByUser_IdAndStatus(userId, status, pageable);
+        if (status == MyRegistrationStatusFilter.CANCELED) {
+            return getCanceledRegistrations(userId, pageable);
         }
 
-        return MyRegistrationRes.from(page);
+        return getActiveRegistrations(userId, pageable);
+
     }
 
+    // ACTIVE status 접수
+    private MyRegistrationRes getActiveRegistrations(Long userId, Pageable pageable) {
 
+        Pageable sortedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(
+                        Sort.Order.desc("appliedAt"),
+                        Sort.Order.desc("id")
+                )
+        );
+
+        Page<Registration> page = registrationRepository.findByUser_Id(userId, sortedPageable);
+
+        return MyRegistrationRes.fromActive(page);
+
+    }
+
+    // CANCEL status 접수
+    private MyRegistrationRes getCanceledRegistrations(Long userId, Pageable pageable) {
+
+        Pageable sortedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(
+                        Sort.Order.desc("canceledAt"),
+                        Sort.Order.desc("id")
+                )
+        );
+
+        // 1. 취소 이력 페이지 조회
+        Page<RegistrationCancelHistory> page = registrationCancelHistoryRepository.findByUserId(userId, sortedPageable);
+
+        // 2. 마라톤/코스 정보 재조회 위한 id 추출
+        List<Long> marathonIds = page.getContent().stream()
+                .map(RegistrationCancelHistory::getMarathonId)
+                .distinct()
+                .toList();
+
+        List<Long> courseIds = page.getContent().stream()
+                .map(RegistrationCancelHistory::getCourseId)
+                .distinct()
+                .toList();
+
+        // 3. 각각 한 번에 조회 후 Map으로 변환
+        Map<Long, Marathon> marathonMap = marathonRepository.findAllById(marathonIds).stream()
+                .collect(Collectors.toMap(Marathon::getId, Function.identity()));
+
+        Map<Long, Course> courseMap = courseRepository.findAllById(courseIds).stream()
+                .collect(Collectors.toMap(Course::getId, Function.identity()));
+
+        // 4. 취소 이력 + 마라톤/코스 정보 결과를 합친 DTO 반환
+        return MyRegistrationRes.fromCanceled(page, marathonMap, courseMap);
+
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #154 

## 🛠️ 작업 내용
- [x] `MyRegistrationStatusFilter` enum 추가
- [x] `GET /api/v1/registrations/me` 에서 `status=ACTIVE / CANCELED` 분기 처리 추가
- [x] 정상 접수는 `Registration` 테이블, 취소 접수는 `RegistrationCancelHistory` 테이블에서 조회하도록 서비스 로직 구현


## 🎯 리뷰 포인트
- `ACTIVE / CANCELED` 를 조회 분기용 필터로 두었습니다.
- 취소 이력 조회 시 마라톤/코스 정보를 `marathonId`, `courseId` 기반 재조회로 처리하였습니다.
- `MyRegistrationRes` DTO 하나로 정상/취소 응답 구조를 통합하였습니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?