### PR TITLE
chore: multifilepart image (#166)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/controller/MarathonController.java
@@ -13,20 +13,24 @@ import com.rungo.api.domain.marathon.marathon.service.MarathonService;
 import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
+import com.rungo.api.global.file.FileStorageService;
 import com.rungo.api.global.response.ApiResponse;
 import com.rungo.api.global.security.SecurityUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -37,12 +41,11 @@ import java.util.List;
 public class MarathonController {
 
     private final MarathonService marathonService;
-    private final MarathonRepository marathonRepository;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<CreateMarathonRes>> createMarathon(
             @AuthenticationPrincipal SecurityUser user,
-            @Valid @RequestBody CreateMarathonReq req
+            @Valid @ModelAttribute CreateMarathonReq req
     ) {
         if (user == null) {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
@@ -89,7 +92,7 @@ public class MarathonController {
     public ResponseEntity<ApiResponse<UpdateMarathonRes>> update(
             @AuthenticationPrincipal SecurityUser user,
             @PathVariable Long marathonId,
-            @Valid @RequestBody UpdateMarathonReq req
+            @Valid @ModelAttribute UpdateMarathonReq req
     ) {
         UpdateMarathonRes res =
                 marathonService.updateMarathon(user.getId(), marathonId, req);

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/create/CreateMarathonReq.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/create/CreateMarathonReq.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -24,7 +25,7 @@ public record CreateMarathonReq(
         @NotNull(message = "대회 일자는 필수입니다.")
         LocalDate eventDate,
 
-        String posterImageUrl,
+        MultipartFile posterImage,
 
         @NotNull(message = "접수 시작일시는 필수입니다.")
         LocalDateTime registrationStartAt,

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/update/UpdateMarathonReq.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/dto/update/UpdateMarathonReq.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -17,7 +18,7 @@ public record UpdateMarathonReq(
         String region,
         String detailedAddress,
         LocalDate eventDate,
-        String posterImageUrl,
+        MultipartFile posterImage,
         LocalDateTime registrationStartAt,
         LocalDateTime registrationEndAt,
 

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -23,6 +23,7 @@ import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
+import com.rungo.api.global.file.FileStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -48,6 +49,7 @@ public class MarathonService {
     private final RegistrationRepository registrationRepository;
     private final RegistrationCancelHistoryRepository registrationCancelHistoryRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final FileStorageService fileStorageService;
 
     @Value("${marathon.min-days.start-to-end}")
     private long minDaysBetweenStartAndEnd;
@@ -59,6 +61,8 @@ public class MarathonService {
     public CreateMarathonRes createMarathon(Long id, CreateMarathonReq req) {
 
         Users organizer = findOrganizer(id);
+
+        String posterImageUrl = fileStorageService.saveMarathonPoster(req.posterImage());
 
         // 대회 접수 시작일이 종료일보다 이후이면 예외 처리
         if (req.registrationStartAt().isAfter(req.registrationEndAt())) {
@@ -91,7 +95,7 @@ public class MarathonService {
                 req.region(),
                 req.detailedAddress(),
                 req.eventDate(),
-                req.posterImageUrl(),
+                posterImageUrl,
                 req.registrationStartAt(),
                 req.registrationEndAt()
         );
@@ -210,6 +214,8 @@ public class MarathonService {
                 req.eventDate()
         );
 
+        String posterImageUrl = fileStorageService.saveMarathonPoster(req.posterImage());
+
         //기존에 있는 Course를 Map으로 저장
         Map<Long, Course> courseMap = toCourseMap(marathon);
 
@@ -223,7 +229,7 @@ public class MarathonService {
                 req.region(),
                 req.detailedAddress(),
                 req.eventDate(),
-                req.posterImageUrl(),
+                posterImageUrl,
                 req.registrationStartAt(),
                 req.registrationEndAt()
         );

--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -208,10 +208,22 @@ public class MarathonService {
             throw new CustomException(ErrorCode.MARATHON_ALREADY_CANCELED);
         }
 
+        LocalDateTime registrationStartAt = req.registrationStartAt() != null
+                ? req.registrationStartAt()
+                : marathon.getRegistrationStartAt();
+
+        LocalDateTime registrationEndAt = req.registrationEndAt() != null
+                ? req.registrationEndAt()
+                : marathon.getRegistrationEndAt();
+
+        LocalDate eventDate = req.eventDate() != null
+                ? req.eventDate()
+                : marathon.getEventDate();
+
         validateMarathonSchedule(
-                req.registrationStartAt(),
-                req.registrationEndAt(),
-                req.eventDate()
+                registrationStartAt,
+                registrationEndAt,
+                eventDate
         );
 
         String posterImageUrl = fileStorageService.saveMarathonPoster(req.posterImage());

--- a/backend/src/main/java/com/rungo/api/global/config/WebResourceConfig.java
+++ b/backend/src/main/java/com/rungo/api/global/config/WebResourceConfig.java
@@ -1,0 +1,22 @@
+package com.rungo.api.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebResourceConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    //클라이언트에서 /images/** 경로로 요청이 들어오면, 실제 파일 시스템의 uploadDir 위치에서 해당 파일을 찾아 응답하도록 설정
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadDir + "/");
+
+    }
+
+}

--- a/backend/src/main/java/com/rungo/api/global/file/FileStorageService.java
+++ b/backend/src/main/java/com/rungo/api/global/file/FileStorageService.java
@@ -1,0 +1,92 @@
+package com.rungo.api.global.file;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+
+public class FileStorageService {
+
+    @Value("${file.upload-dir}")
+
+    private String uploadDir;
+
+    public String saveMarathonPoster(MultipartFile file) {
+
+        if (file == null || file.isEmpty()) {
+
+            return null;
+
+        }
+
+        validateImage(file);
+
+        try {
+
+            String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
+
+            String extension = extractExtension(originalFilename);
+
+            String storedFileName = UUID.randomUUID() + (extension.isBlank() ? "" : "." + extension);
+
+            Path marathonDir = Paths.get(uploadDir, "marathons");
+
+            Files.createDirectories(marathonDir);
+
+            Path targetPath = marathonDir.resolve(storedFileName);
+
+            file.transferTo(targetPath);
+
+            return "/images/marathons/" + storedFileName;
+
+        } catch (IOException e) {
+
+            throw new IllegalStateException("포스터 이미지 저장에 실패했습니다.", e);
+
+        }
+
+    }
+
+    private void validateImage(MultipartFile file) {
+
+        String contentType = file.getContentType();
+
+        if (contentType == null ||
+
+                (!contentType.equals("image/png")
+
+                        && !contentType.equals("image/jpeg")
+
+                        && !contentType.equals("image/jpg")
+
+                        && !contentType.equals("image/webp"))) {
+
+            throw new IllegalArgumentException("이미지 파일만 업로드할 수 있습니다.");
+
+        }
+
+    }
+
+    private String extractExtension(String filename) {
+
+        int lastDotIndex = filename.lastIndexOf(".");
+
+        if (lastDotIndex == -1) {
+
+            return "";
+
+        }
+
+        return filename.substring(lastDotIndex + 1).toLowerCase();
+
+    }
+
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -55,7 +55,7 @@ marathon:
   min-days:
     start-to-end: 1
     end-to-event: 1
-    
+
 app:
   mail:
     enabled: false
@@ -64,3 +64,5 @@ lock:
   reissue:
     wait-time: 1
     lease-time: 2
+file:
+  upload-dir: /Users/admin/uploads


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #166 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 마라톤 대회 생성 시 포스터 이미지 업로드 기능 구현 (MultipartFile 적용)
- [x] 이미지 파일을 로컬 디렉토리( /Users/admin/uploads)에 저장하고 URL 형태로 반환하도록 구현
- [x] FileStorageService 구현 (UUID 기반 파일명 생성 및 이미지 타입 검증)
- [x] 마라톤 생성,수정 API를 multipart/form-data 방식으로 변경 (@ModelAttribute 적용) 


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
- 마라톤 생성/수정 시 이미지 파일을 MultipartFile로 받아 로컬 디렉토리에 저장한 뒤, DB에는 실제 파일이 아닌 접근용 URL만 저장하도록 구현했습니다. 
-  /images/** 요청을 로컬 파일 시스템 경로와 매핑하여 브라우저에서 이미지 조회가 가능하도록 구성했습니다.
## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?