### PR TITLE
refactor: 401, 403 에러 분리 (#169)

### DIFF
--- a/backend/src/main/java/com/rungo/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/rungo/api/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -43,6 +44,23 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
+
+                // exceptionHandling 적용
+                .exceptionHandling(ex -> ex
+                        // 인증이 안 됐을 경우 401
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"message\": \"인증이 필요합니다.\"}");
+                        })
+                        // 인증은 됐지만 권한이 부족한 경우 403
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setStatus(HttpStatus.FORBIDDEN.value());
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"message\": \"접근 권한이 없습니다.\"}");
+                        })
+                )
+
                 .authorizeHttpRequests(auth -> auth
 
                         // AUTH, SWAGGER: 인증 없이 접근 허용

--- a/backend/src/main/java/com/rungo/api/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/rungo/api/global/security/CustomAuthenticationFilter.java
@@ -66,6 +66,14 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 
                         SecurityContextHolder.getContext().setAuthentication(authentication);
                     }
+
+                    else {
+                        // 토큰이 있지만 유효하지 않을 경우 401
+                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                        response.setContentType("application/json;charset=UTF-8");
+                        response.getWriter().write("{\"message\": \"유효하지 않은 액세스 토큰입니다.\"}");
+                        return; // 필터 체인 중단
+                    }
                 }
             }
         }

--- a/backend/src/test/java/com/rungo/api/global/security/CustomAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/rungo/api/global/security/CustomAuthenticationFilterTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -113,5 +114,15 @@ class CustomAuthenticationFilterTest {
                         .cookie(new Cookie(COOKIE_NAME, token)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.role").value("ADMIN"));
+    }
+
+    @Test
+    @DisplayName("PARTICIPANT가 ORGANIZER 전용 API 호출 시 403을 반환한다.")
+    void participantAccessOrganizerApi_returns403() throws Exception {
+        String token = validToken(1L, "user@test.com", Role.PARTICIPANT);
+
+        mockMvc.perform(post("/api/v1/marathons")
+                        .cookie(new Cookie(COOKIE_NAME, token)))
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #169

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] `SecurityConfig`에 `exceptionHandling` 추가 — 미인증 요청 401, 권한 부족 403 명시적 분리
- [x] `CustomAuthenticationFilter`에서 만료/변조 토큰 감지 시 필터 체인 중단(return) 후 401 응답


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.

현재 문제점은 `SecurityConfig`에 `exceptionHandling(Spring Security에서 제공하는 예외 처리 설정 메서드)`이 설정되지 않아 **Spring Security 기본 동작**으로 인증 실패와 권한 부족 모두 403을 반환했습니다. 따라서 `exceptionHandling`을 추가하여 인증/인가 실패를 명시적으로 구분했고, 필터 테스트 모두 통과한 것을 확인했습니다.

- 현재 방식이 적절한지 확인 부탁드립니다.

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?