### PR TITLE
feat: 소셜 로그인 기능 추가 (#176)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -49,7 +49,6 @@ dependencies {
 	implementation("org.springframework.retry:spring-retry")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 
-	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("io.micrometer:micrometer-registry-prometheus")
 
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
 
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("io.micrometer:micrometer-registry-prometheus")
+
+	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/rungo/api/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/controller/AuthController.java
@@ -12,6 +12,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -91,5 +94,35 @@ public class AuthController {
         CookieUtil.addCookie(response, "refreshToken", tokenRes.refreshToken(), REFRESH_TOKEN_EXPIRE);
 
         return ResponseEntity.ok(ApiResponse.okMessage("토큰이 재발급되었습니다."));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<MeRes>> me(Authentication authentication) {
+        String email = extractEmail(authentication);
+        MeRes res = authService.getMe(email);
+        return ResponseEntity.ok(ApiResponse.ok(res));
+    }
+
+    private String extractEmail(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalArgumentException("인증 정보가 없습니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof OAuth2User oAuth2User) {
+            return (String) oAuth2User.getAttributes().get("email");
+        }
+
+        if (principal instanceof UserDetails userDetails) {
+            return userDetails.getUsername();
+        }
+
+        if (principal instanceof String str) {
+            return str;
+        }
+
+        throw new IllegalArgumentException("지원하지 않는 인증 타입");
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/auth/dto/MeRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/dto/MeRes.java
@@ -1,21 +1,22 @@
 package com.rungo.api.domain.auth.dto;
 
 import com.rungo.api.domain.users.entity.Users;
-import lombok.Builder;
+import com.rungo.api.domain.users.enumtype.Role;
 
-@Builder
 public record MeRes(
         Long id,
         String email,
         String name,
-        String role
+        Role role,
+        boolean profileCompleted
 ) {
     public static MeRes from(Users user) {
-        return MeRes.builder()
-                    .id(user.getId())
-                    .email(user.getEmail())
-                    .name(user.getName())
-                    .role(user.getRole().name())
-                    .build();
+        return new MeRes(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole(),
+                user.isProfileCompleted()
+        );
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/auth/dto/MeRes.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/dto/MeRes.java
@@ -1,0 +1,21 @@
+package com.rungo.api.domain.auth.dto;
+
+import com.rungo.api.domain.users.entity.Users;
+import lombok.Builder;
+
+@Builder
+public record MeRes(
+        Long id,
+        String email,
+        String name,
+        String role
+) {
+    public static MeRes from(Users user) {
+        return MeRes.builder()
+                    .id(user.getId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .role(user.getRole().name())
+                    .build();
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/auth/entity/UserAuth.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/entity/UserAuth.java
@@ -1,0 +1,56 @@
+package com.rungo.api.domain.auth.entity;
+
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Provider;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "user_auth",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_provider_provider_id", columnNames = {"provider", "provider_id"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserAuth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Provider provider;
+
+    @Column(name = "provider_id", nullable = false, length = 255)
+    private String providerId;
+
+    @Column(length = 255)
+    private String password;
+
+    public static UserAuth createLocalAuth(Users user, String encodedPassword) {
+        return UserAuth.builder()
+                       .user(user)
+                       .provider(Provider.LOCAL)
+                       .providerId(user.getEmail())
+                       .password(encodedPassword)
+                       .build();
+    }
+
+    public static UserAuth createSocialAuth(Users user, Provider provider, String providerId) {
+        return UserAuth.builder()
+                       .user(user)
+                       .provider(provider)
+                       .providerId(providerId)
+                       .password(null)
+                       .build();
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/auth/entity/UserAuth.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/entity/UserAuth.java
@@ -9,7 +9,10 @@ import lombok.*;
 @Table(
         name = "user_auth",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_provider_provider_id", columnNames = {"provider", "provider_id"})
+                @UniqueConstraint(
+                        name = "uk_provider_provider_id",
+                        columnNames = {"provider", "provider_id"}
+                )
         }
 )
 @Getter

--- a/backend/src/main/java/com/rungo/api/domain/auth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,21 @@
+package com.rungo.api.domain.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "OAuth2 Login Failed");
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,21 @@
+package com.rungo.api.domain.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        response.sendRedirect("http://localhost:3000");
+    }
+}

--- a/backend/src/main/java/com/rungo/api/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,21 +1,60 @@
 package com.rungo.api.domain.auth.handler;
 
-import jakarta.servlet.ServletException;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.repository.UserRepository;
+import com.rungo.api.global.util.CookieUtil;
+import com.rungo.api.global.util.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final UserRepository userRepository;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
-        response.sendRedirect("http://localhost:3000");
+                                        Authentication authentication) throws IOException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        String email = (String) oAuth2User.getAttributes().get("email");
+
+        Users user = userRepository.findByEmail(email)
+                                   .orElseThrow();
+
+        String accessToken = JwtUtil.generateAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole(),
+                secret
+        );
+
+        String refreshToken = JwtUtil.generateRefreshToken(
+                user.getId(),
+                user.getEmail(),
+                secret
+        );
+
+        CookieUtil.addCookie(response, "accessToken", accessToken, 60 * 60);
+        CookieUtil.addCookie(response, "refreshToken", refreshToken, 60 * 60 * 24 * 7);
+
+        response.sendRedirect(frontendUrl);
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/auth/repository/UserAuthRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/repository/UserAuthRepository.java
@@ -3,12 +3,14 @@ package com.rungo.api.domain.auth.repository;
 import com.rungo.api.domain.auth.entity.UserAuth;
 import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Provider;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
 
+    @EntityGraph(attributePaths = "user")
     Optional<UserAuth> findByProviderAndProviderId(Provider provider, String providerId);
 
     Optional<UserAuth> findByUser_EmailAndProvider(String email, Provider provider);

--- a/backend/src/main/java/com/rungo/api/domain/auth/repository/UserAuthRepository.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/repository/UserAuthRepository.java
@@ -1,0 +1,17 @@
+package com.rungo.api.domain.auth.repository;
+
+import com.rungo.api.domain.auth.entity.UserAuth;
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
+
+    Optional<UserAuth> findByProviderAndProviderId(Provider provider, String providerId);
+
+    Optional<UserAuth> findByUser_EmailAndProvider(String email, Provider provider);
+
+    boolean existsByUserAndProvider(Users user, Provider provider);
+}

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
@@ -161,4 +161,12 @@ public class AuthService {
             }
         }
     }
+
+    public MeRes getMe(String email) {
+
+        Users user = userRepository.findByEmail(email)
+                                   .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return MeRes.from(user);
+    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/AuthService.java
@@ -1,7 +1,10 @@
 package com.rungo.api.domain.auth.service;
 
 import com.rungo.api.domain.auth.dto.*;
+import com.rungo.api.domain.auth.entity.UserAuth;
+import com.rungo.api.domain.auth.repository.UserAuthRepository;
 import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Provider;
 import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
 import com.rungo.api.global.exception.CustomException;
@@ -31,6 +34,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenService refreshTokenService;
     private final UserRepository userRepository;
+    private final UserAuthRepository userAuthRepository;
 
     private static final String REISSUE_LOCK_PREFIX = "lock:reissue:";
 
@@ -52,7 +56,6 @@ public class AuthService {
 
         Users user = Users.builder()
                           .email(req.email())
-                          .password(passwordEncoder.encode(req.password()))
                           .name(req.name())
                           .phoneNumber(req.phoneNumber())
                           .gender(req.gender())
@@ -61,6 +64,10 @@ public class AuthService {
                           .build();
 
         Users savedUser = userRepository.save(user);
+
+        userAuthRepository.save(
+                UserAuth.createLocalAuth(savedUser, passwordEncoder.encode(req.password()))
+        );
 
         return new SignUpRes(
                 savedUser.getId(),
@@ -77,12 +84,15 @@ public class AuthService {
     @Transactional
     public LoginResult login(LoginReq req) {
 
-        Users user = userRepository.findByEmail(req.email())
-                                   .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        UserAuth userAuth = userAuthRepository.findByUser_EmailAndProvider(req.email(), Provider.LOCAL)
+                                              .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(req.password(), user.getPassword())) {
+        if (userAuth.getPassword() == null ||
+                !passwordEncoder.matches(req.password(), userAuth.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
+
+        Users user = userAuth.getUser();
 
         String accessToken = JwtUtil.generateAccessToken(
                 user.getId(),

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
@@ -1,8 +1,54 @@
 package com.rungo.api.domain.auth.service;
 
+import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Role;
+import com.rungo.api.domain.users.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Map;
+
 @Service
+@RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String email = (String) attributes.get("email");
+
+        if (email == null) {
+            throw new RuntimeException("Email not found from OAuth2");
+        }
+
+        String name = (String) attributes.get("name");
+
+        Users user = userRepository.findByEmail(email)
+                                   .orElseGet(() -> userRepository.save(
+                                           Users.builder()
+                                                .email(email)
+                                                .name(name)
+                                                .role(Role.PARTICIPANT)
+                                                .build()
+                                   ));
+
+        return new DefaultOAuth2User(
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())),
+                attributes,
+                "email"
+        );
+    }
 }

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
@@ -1,6 +1,9 @@
 package com.rungo.api.domain.auth.service;
 
+import com.rungo.api.domain.auth.entity.UserAuth;
+import com.rungo.api.domain.auth.repository.UserAuthRepository;
 import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Provider;
 import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,30 +23,47 @@ import java.util.Map;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
+    private final UserAuthRepository userAuthRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-
         OAuth2User oAuth2User = super.loadUser(userRequest);
-
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
         String email = (String) attributes.get("email");
+        String name = (String) attributes.get("name");
+        String providerId = (String) attributes.get("sub");
 
         if (email == null) {
             throw new RuntimeException("Email not found from OAuth2");
         }
 
-        String name = (String) attributes.get("name");
+        if (name == null || name.isBlank()) {
+            name = email.split("@")[0];
+        }
 
-        Users user = userRepository.findByEmail(email)
-                                   .orElseGet(() -> userRepository.save(
-                                           Users.builder()
-                                                .email(email)
-                                                .name(name)
-                                                .role(Role.PARTICIPANT)
-                                                .build()
-                                   ));
+        final String finalName = name;
+
+        Users user = userAuthRepository.findByProviderAndProviderId(Provider.GOOGLE, providerId)
+                                       .map(UserAuth::getUser)
+                                       .orElseGet(() -> {
+                                           Users existingUser = userRepository.findByEmail(email)
+                                                                              .orElseGet(() -> userRepository.save(
+                                                                                      Users.builder()
+                                                                                           .email(email)
+                                                                                           .name(finalName)
+                                                                                           .role(Role.PARTICIPANT)
+                                                                                           .build()
+                                                                              ));
+
+                                           if (!userAuthRepository.existsByUserAndProvider(existingUser, Provider.GOOGLE)) {
+                                               userAuthRepository.save(
+                                                       UserAuth.createSocialAuth(existingUser, Provider.GOOGLE, providerId)
+                                               );
+                                           }
+
+                                           return existingUser;
+                                       });
 
         return new DefaultOAuth2User(
                 List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())),

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,8 @@
+package com.rungo.api.domain.auth.service;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+}

--- a/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/rungo/api/domain/auth/service/CustomOAuth2UserService.java
@@ -6,6 +6,7 @@ import com.rungo.api.domain.users.entity.Users;
 import com.rungo.api.domain.users.enumtype.Provider;
 import com.rungo.api.domain.users.enumtype.Role;
 import com.rungo.api.domain.users.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -20,6 +21,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;

--- a/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationService.java
+++ b/backend/src/main/java/com/rungo/api/domain/registration/service/RegistrationService.java
@@ -53,6 +53,11 @@ public class RegistrationService {
 
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.isProfileCompleted()) {
+            throw new CustomException(ErrorCode.PROFILE_NOT_COMPLETED);
+        }
+
         Course course = courseRepository.findById(request.courseId())
                 .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
         Marathon marathon = course.getMarathon();

--- a/backend/src/main/java/com/rungo/api/domain/users/controller/UsersController.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/controller/UsersController.java
@@ -1,5 +1,6 @@
 package com.rungo.api.domain.users.controller;
 
+import com.rungo.api.domain.users.dto.CompleteProfileReq;
 import com.rungo.api.domain.users.dto.MyProfileRes;
 import com.rungo.api.domain.users.dto.UpdateMyProfileReq;
 import com.rungo.api.domain.users.dto.UpdateMyProfileRes;
@@ -33,12 +34,11 @@ public class UsersController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
     })
-    public MyProfileRes getMyInfo(@AuthenticationPrincipal SecurityUser user) {
-        // 인증이 실패된 객체라면
+    public ResponseEntity<ApiResponse<MyProfileRes>> getMyInfo(@AuthenticationPrincipal SecurityUser user) {        // 인증이 실패된 객체라면
         if (user == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
-        return userService.getMyInfo(user.getId());
+        return ResponseEntity.ok(ApiResponse.ok(userService.getMyInfo(user.getId())));
     }
 
     @PatchMapping("/me")
@@ -57,11 +57,29 @@ public class UsersController {
         }
 
         // 모든 필드가 null이면 의미 없는 요청
-        if (req.name() == null && req.phoneNumber() == null) {
+        if (req.name() == null &&
+                req.phoneNumber() == null &&
+                req.gender() == null &&
+                req.birth() == null) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
         UpdateMyProfileRes res = userService.updateMyProfile(user.getId(), req);
         return ResponseEntity.ok(ApiResponse.ok(res));
     }
+
+    @PatchMapping("/me/complete")
+    @Operation(summary = "내 정보 보완", description = "소셜 로그인 사용자의 추가 정보를 처음 입력합니다.")
+    public ResponseEntity<ApiResponse<Void>> completeMyProfile(
+            @AuthenticationPrincipal SecurityUser user,
+            @Valid @RequestBody CompleteProfileReq req
+    ) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        userService.completeMyProfile(user.getId(), req);
+        return ResponseEntity.ok(ApiResponse.okMessage("프로필이 보완되었습니다."));
+    }
+
 }

--- a/backend/src/main/java/com/rungo/api/domain/users/dto/CompleteProfileReq.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/dto/CompleteProfileReq.java
@@ -1,0 +1,27 @@
+package com.rungo.api.domain.users.dto;
+
+import com.rungo.api.domain.users.enumtype.Gender;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+
+public record CompleteProfileReq(
+        @NotBlank String name,
+
+        @NotBlank
+        @Pattern(
+                regexp = "^010-\\d{4}-\\d{4}$",
+                message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
+        )
+        String phoneNumber,
+
+        @NotNull Gender gender,
+
+        @NotNull
+        @Past(message = "생년월일은 과거 날짜여야 합니다.")
+        LocalDate birth
+) {
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/dto/UpdateMyProfileReq.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/dto/UpdateMyProfileReq.java
@@ -1,8 +1,12 @@
 package com.rungo.api.domain.users.dto;
 
+import com.rungo.api.domain.users.enumtype.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
 
 @Schema(description = "내 정보 수정 요청 DTO")
 public record UpdateMyProfileReq (
@@ -13,9 +17,16 @@ public record UpdateMyProfileReq (
 
         @Schema(description = "전화번호", example = "010-1234-5678")
         @Pattern(
-                regexp = "^01[016789]-?\\d{3,4}-?\\d{4}$",
+                regexp = "^010-\\d{4}-\\d{4}$",
                 message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
         )
-        String phoneNumber
+        String phoneNumber,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender gender,
+
+        @Schema(description = "생년월일", example = "1990-01-01")
+        @Past(message = "생년월일은 과거 날짜여야 합니다.")
+        LocalDate birth
 
 ) {}

--- a/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
@@ -1,6 +1,5 @@
 package com.rungo.api.domain.users.entity;
 
-import com.rungo.api.domain.auth.entity.UserAuth;
 import com.rungo.api.domain.users.enumtype.Gender;
 import com.rungo.api.domain.users.enumtype.Role;
 import jakarta.persistence.*;
@@ -11,8 +10,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "users")
@@ -54,9 +51,6 @@ public class Users {
 
     @Column
     private LocalDate birth;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<UserAuth> userAuths = new ArrayList<>();
 
     // 내 프로필 수정 (name, phoneNumber)
     public void updateProfile(String name, String phoneNumber, Gender gender, LocalDate birth) {

--- a/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
@@ -53,7 +53,7 @@ public class Users {
     private LocalDate birth;
 
     // 내 프로필 수정 (name, phoneNumber)
-    public void updateProfile(String name, String phoneNumber) {
+    public void updateProfile(String name, String phoneNumber, Gender gender, LocalDate birth) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.gender = gender;

--- a/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
@@ -27,13 +27,10 @@ public class Users {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
-    @Column(nullable = false, length = 255)
-    private String password;
-
     @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(name = "phone_number", nullable = false, length = 20)
+    @Column(name = "phone_number", length = 20)
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)
@@ -49,20 +46,26 @@ public class Users {
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column
     private Gender gender;
 
-    @Column(nullable = false)
+    @Column
     private LocalDate birth;
 
     // 내 프로필 수정 (name, phoneNumber)
     public void updateProfile(String name, String phoneNumber) {
         this.name = name;
         this.phoneNumber = phoneNumber;
+        this.gender = gender;
+        this.birth = birth;
     }
 
     //주최자로 승급
     public void promoteToOrganizer() {
         this.role = Role.ORGANIZER;
+    }
+
+    public boolean isProfileCompleted() {
+        return phoneNumber != null && gender != null && birth != null;
     }
 }

--- a/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/entity/Users.java
@@ -1,5 +1,6 @@
 package com.rungo.api.domain.users.entity;
 
+import com.rungo.api.domain.auth.entity.UserAuth;
 import com.rungo.api.domain.users.enumtype.Gender;
 import com.rungo.api.domain.users.enumtype.Role;
 import jakarta.persistence.*;
@@ -10,6 +11,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "users")
@@ -51,6 +54,9 @@ public class Users {
 
     @Column
     private LocalDate birth;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserAuth> userAuths = new ArrayList<>();
 
     // 내 프로필 수정 (name, phoneNumber)
     public void updateProfile(String name, String phoneNumber, Gender gender, LocalDate birth) {

--- a/backend/src/main/java/com/rungo/api/domain/users/enumtype/Provider.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/enumtype/Provider.java
@@ -1,0 +1,8 @@
+package com.rungo.api.domain.users.enumtype;
+
+public enum Provider {
+    LOCAL,
+    GOOGLE,
+    KAKAO,
+    NAVER
+}

--- a/backend/src/main/java/com/rungo/api/domain/users/service/UsersService.java
+++ b/backend/src/main/java/com/rungo/api/domain/users/service/UsersService.java
@@ -1,15 +1,19 @@
 package com.rungo.api.domain.users.service;
 
+import com.rungo.api.domain.users.dto.CompleteProfileReq;
 import com.rungo.api.domain.users.dto.MyProfileRes;
 import com.rungo.api.domain.users.dto.UpdateMyProfileReq;
 import com.rungo.api.domain.users.dto.UpdateMyProfileRes;
 import com.rungo.api.domain.users.entity.Users;
+import com.rungo.api.domain.users.enumtype.Gender;
 import com.rungo.api.domain.users.repository.UserRepository;
 import com.rungo.api.global.exception.CustomException;
 import com.rungo.api.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -35,15 +39,15 @@ public class UsersService {
 
     @Transactional
     public UpdateMyProfileRes updateMyProfile(Long userId, UpdateMyProfileReq req) {
-
         Users user = usersRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // null인 필드는 기존 값 유지
         String newName = req.name() != null ? req.name() : user.getName();
         String newPhoneNumber = req.phoneNumber() != null ? req.phoneNumber() : user.getPhoneNumber();
+        Gender newGender = req.gender() != null ? req.gender() : user.getGender();
+        LocalDate newBirth = req.birth() != null ? req.birth() : user.getBirth();
 
-        user.updateProfile(newName, newPhoneNumber);
+        user.updateProfile(newName, newPhoneNumber, newGender, newBirth);
 
         return new UpdateMyProfileRes(
                 user.getId(),
@@ -54,5 +58,22 @@ public class UsersService {
                 user.getBirth(),
                 user.getRole()
         );
+
+
+
     }
+
+    @Transactional
+    public void completeMyProfile(Long userId, CompleteProfileReq req) {
+        Users user = usersRepository.findById(userId)
+                                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateProfile(
+                req.name(),
+                req.phoneNumber(),
+                req.gender(),
+                req.birth()
+        );
+    }
+
 }

--- a/backend/src/main/java/com/rungo/api/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/rungo/api/global/config/DataInitializer.java
@@ -28,15 +28,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@Profile("init & !test")
+@Profile("!test")
 @Configuration
 @RequiredArgsConstructor
 public class DataInitializer {
 
     private static final String TEST_PASSWORD = "Password123!";
-    private static final int TEST_USER_COUNT = 10002;
-    private static final int CANCEL_TEST_MARATHON_COUNT = 5000;
-    private static final int USER_BATCH_SIZE = 500;
+    private static final int TEST_USER_COUNT = 10;
+    private static final int CANCEL_TEST_MARATHON_COUNT = 100;
+    private static final int USER_BATCH_SIZE = 10;
 
     private final UserRepository userRepository;
     private final UserAuthRepository userAuthRepository;
@@ -159,7 +159,7 @@ public class DataInitializer {
         Course course = new Course(
                 "10K",
                 BigDecimal.valueOf(30000),
-                15000,
+                40000,
                 0
         );
 
@@ -208,7 +208,7 @@ public class DataInitializer {
             Course course = new Course(
                     "10K",
                     BigDecimal.valueOf(30000),
-                    15000,
+                    40000,
                     0
             );
             marathon.addCourse(course);

--- a/backend/src/main/java/com/rungo/api/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/rungo/api/global/config/DataInitializer.java
@@ -1,5 +1,7 @@
 package com.rungo.api.global.config;
 
+import com.rungo.api.domain.auth.entity.UserAuth;
+import com.rungo.api.domain.auth.repository.UserAuthRepository;
 import com.rungo.api.domain.marathon.course.entity.Course;
 import com.rungo.api.domain.marathon.course.repository.CourseRepository;
 import com.rungo.api.domain.marathon.marathon.entity.Marathon;
@@ -37,6 +39,7 @@ public class DataInitializer {
     private static final int USER_BATCH_SIZE = 500;
 
     private final UserRepository userRepository;
+    private final UserAuthRepository userAuthRepository;
     private final MarathonRepository marathonRepository;
     private final CourseRepository courseRepository;
     private final RegistrationRepository registrationRepository;
@@ -58,17 +61,24 @@ public class DataInitializer {
 
     private Users initOrganizer() {
         return userRepository.findByEmail("organizer@test.com")
-                             .orElseGet(() -> userRepository.save(
-                                     Users.builder()
-                                          .email("organizer@test.com")
-                                          .password(passwordEncoder.encode(TEST_PASSWORD))
-                                          .name("주최자")
-                                          .phoneNumber("010-2222-2222")
-                                          .role(Role.ORGANIZER)
-                                          .gender(Gender.MALE)
-                                          .birth(LocalDate.of(2000, 1, 1))
-                                          .build()
-                             ));
+                             .orElseGet(() -> {
+                                 Users savedUser = userRepository.save(
+                                         Users.builder()
+                                              .email("organizer@test.com")
+                                              .name("주최자")
+                                              .phoneNumber("010-2222-2222")
+                                              .role(Role.ORGANIZER)
+                                              .gender(Gender.MALE)
+                                              .birth(LocalDate.of(2000, 1, 1))
+                                              .build()
+                                 );
+
+                                 userAuthRepository.save(
+                                         UserAuth.createLocalAuth(savedUser, passwordEncoder.encode(TEST_PASSWORD))
+                                 );
+
+                                 return savedUser;
+                             });
     }
 
     private void initParticipants() {
@@ -91,7 +101,6 @@ public class DataInitializer {
             batch.add(
                     Users.builder()
                          .email(email)
-                         .password(passwordEncoder.encode(TEST_PASSWORD))
                          .name("참가자" + i)
                          .phoneNumber(String.format("010-%04d-%04d", i / 10000, i % 10000))
                          .role(Role.PARTICIPANT)
@@ -101,17 +110,27 @@ public class DataInitializer {
             );
 
             if (batch.size() == USER_BATCH_SIZE) {
-                userRepository.saveAll(batch);
+                saveUsersWithLocalAuth(batch);
                 System.out.println("테스트 유저 저장 진행중: " + i + "명");
                 batch.clear();
             }
         }
 
         if (!batch.isEmpty()) {
-            userRepository.saveAll(batch);
+            saveUsersWithLocalAuth(batch);
         }
 
         System.out.println("테스트 유저 저장 완료");
+    }
+
+    private void saveUsersWithLocalAuth(List<Users> usersBatch) {
+        List<Users> savedUsers = userRepository.saveAll(usersBatch);
+
+        List<UserAuth> authBatch = savedUsers.stream()
+                                             .map(user -> UserAuth.createLocalAuth(user, passwordEncoder.encode(TEST_PASSWORD)))
+                                             .toList();
+
+        userAuthRepository.saveAll(authBatch);
     }
 
     private void initPerformanceMarathon(Users organizer) {

--- a/backend/src/main/java/com/rungo/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/rungo/api/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.rungo.api.global.config;
 
+import com.rungo.api.domain.auth.handler.OAuth2AuthenticationFailureHandler;
+import com.rungo.api.domain.auth.handler.OAuth2AuthenticationSuccessHandler;
+import com.rungo.api.domain.auth.service.CustomOAuth2UserService;
 import com.rungo.api.global.security.CustomAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +24,9 @@ import java.util.List;
 public class SecurityConfig {
 
     private final CustomAuthenticationFilter customAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
@@ -34,7 +40,7 @@ public class SecurityConfig {
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/api/**", configuration); // CORS 설정 적용
+        source.registerCorsConfiguration("/**", configuration); // CORS 설정 적용
 
         return source;
     }
@@ -69,6 +75,8 @@ public class SecurityConfig {
                                 "/api/v1/auth/login",
                                 "/api/v1/auth/reissue",
                                 "/api/v1/auth/logout",
+                                "/oauth2/**",
+                                "/login/oauth2/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/actuator/prometheus",
@@ -123,6 +131,11 @@ public class SecurityConfig {
 
                         // 그 외: 인증 필요
                         .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .failureHandler(oAuth2AuthenticationFailureHandler)
                 )
                 .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     ALREADY_ORGANIZER(HttpStatus.BAD_REQUEST, "이미 주최자 권한을 가진 회원입니다."),
+    PROFILE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "필수 프로필 정보가 누락되었습니다."),
+
     // 토큰
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),

--- a/backend/src/main/java/com/rungo/api/global/util/JwtUtil.java
+++ b/backend/src/main/java/com/rungo/api/global/util/JwtUtil.java
@@ -82,10 +82,10 @@ public class JwtUtil {
     }
 
      // 이메일 추출
-    public static String getEmail(String token, String secret) {
-        Claims claims = getClaims(token, secret);
-        return claims != null ? claims.get("sub", String.class) : null;
-    }
+     public static String getEmail(String token, String secret) {
+         Claims claims = getClaims(token, secret);
+         return claims != null ? claims.get("email", String.class) : null;
+     }
 
      // 역할 추출
     public static String getRole(String token, String secret) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -45,6 +45,18 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - profile
+              - email
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+
 springdoc:
   default-produces-media-type: application/json; charset=UTF-8
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -71,6 +71,8 @@ marathon:
 app:
   mail:
     enabled: false
+  frontend:
+    url: http://localhost:3000
 
 lock:
   reissue:


### PR DESCRIPTION
## 📌 관련 이슈
Closes #176 

## 🛠️ 작업 내용
- [x] OAuth2(Google) 로그인 기능 추가
- [x] Users / UserAuth 구조 분리
- [x] LOCAL / GOOGLE 로그인 수단 분리 처리
- [x] OAuth2 최소 정보(email, name) 기반 사용자 생성 로직 구현
- [x] Google 로그인 시 동일 이메일의 기존 사용자 계정과 연동 처리
- [x] 프로필 미완성 상태(profileCompleted) 도입
- [x] 추가 정보 입력 API (/users/me/complete) 구현
- [x] 일반 프로필 수정 API (/users/me) 분리
- [x] 마라톤 신청 시 프로필 미완성 사용자 차단 로직 추가

## 주요 변경 사항
### 1. 사용자 구조 개선
- Users -> 사용자 정보만 담당 
- UserAuth -> 로그인 수단 관리 (LOCAL / GOOGLE)

### 2. OAuth2 로그인 처리 방식 변경
- 최초 로그인 시 최소 정보로 회원 생성
- 추가 정보는 이후 입력하도록 분리

### 3. 계정 연동 정책 
- Google 로그인 시 동일 이메일의 기존 계정이 존재하면 해당 계정에 연동 

### 4. 프로필 상태 관리
- profileCompleted 기준으로 서비스 이용 제어
- 미완성 시 신청 기능 제한


## 🎯 리뷰 포인트
- UserAuth 구조 및 provider/providerId 설계 적절성
- 동일 이메일 기반 계정 연동 로직 검증
- profileCompleted 기반 접근 제어 방식
- /users/me vs /users/me/complete API 분리 구조


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="475" height="903" alt="image" src="https://github.com/user-attachments/assets/b7cb66d4-eb68-4648-bac1-ac33ea7d0c66" />
<img width="1253" height="491" alt="image" src="https://github.com/user-attachments/assets/18cddcbf-7cc1-47f5-aa2f-7c90e4851dff" />
<img width="936" height="488" alt="image" src="https://github.com/user-attachments/assets/a079f8c2-d91d-4668-8dbe-8f135cb0279c" />
<img width="937" height="517" alt="image" src="https://github.com/user-attachments/assets/9c794e80-8ee2-4855-a444-91bc0a24584b" />
<img width="1249" height="515" alt="image" src="https://github.com/user-attachments/assets/10ade0b3-5240-4077-a785-24f7a947b79c" />


## 📎 참고
상세 내용은 Notion 문서 참고
(https://www.notion.so/OAuth2-34a15a01205480ac9251e2215aebb717?source=copy_link)

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?