### PR TITLE
chore: 마라톤 CRUD 에러 세분화, 날짜 함수 이용 (#201)

### DIFF
--- a/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
+++ b/backend/src/main/java/com/rungo/api/domain/marathon/marathon/service/MarathonService.java
@@ -64,16 +64,7 @@ public class MarathonService {
 
         String posterImageUrl = fileStorageService.saveMarathonPoster(req.posterImage());
 
-        // 대회 접수 시작일이 종료일보다 이후이면 예외 처리
-        if (req.registrationStartAt().isAfter(req.registrationEndAt())) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        // 대회 개최일이 종료일 보다 이전이면 예외 처리
-        if (req.eventDate().isBefore(req.registrationEndAt().toLocalDate())) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
+        //마라톤 일정 유효성 검증
         validateMarathonSchedule(
                 req.registrationStartAt(),
                 req.registrationEndAt(),
@@ -86,7 +77,7 @@ public class MarathonService {
 
 
             if (!courseTypes.add(normalizeCourseType(courseReq.courseType()))) {
-                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+                throw new CustomException(ErrorCode.COURSE_TYPE_DUPLICATE_ERROR);
             }
         }
         Marathon marathon = Marathon.create(
@@ -204,7 +195,7 @@ public class MarathonService {
 
         //마라톤 접수 전까지만 수정 가능하도록 예외 처리
         if(!LocalDateTime.now().isBefore(marathon.getRegistrationStartAt())){
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new CustomException(ErrorCode.MARATHON_MODIFY_AFTER_REGISTER_START);
         }
 
         if(marathon.isCanceled()){
@@ -315,13 +306,11 @@ public class MarathonService {
                 ? req.eventDate()
                 : marathon.getEventDate();
 
-        if (registrationStartAt.isAfter(registrationEndAt)) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        if (eventDate.isBefore(registrationEndAt.toLocalDate())) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-        }
+        validateMarathonSchedule(
+                registrationStartAt,
+                registrationEndAt,
+                eventDate
+        );
     }
 
     //코스 중복 여부 검사하는 함수
@@ -368,7 +357,7 @@ public class MarathonService {
 
         if (uniqueTypes.size() != finalCourseTypes.size()) {
 
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new CustomException(ErrorCode.COURSE_TYPE_DUPLICATE_ERROR);
         }
     }
 
@@ -384,7 +373,7 @@ public class MarathonService {
                 .count();
 
         if (distinctCount != req.courses().size()) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new CustomException(ErrorCode.COURSE_ID_DUPLICATE_ERROR);
         }
     }
 
@@ -400,22 +389,28 @@ public class MarathonService {
             LocalDateTime registrationEndAt,
             LocalDate eventDate
     ) {
+        //접수 시작이 접수 종료보다 늦을 수 없도록 예외 처리
         if (registrationStartAt.isAfter(registrationEndAt)) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new CustomException(ErrorCode.MARATHON_REGISTER_START_END_ERROR);
+        }
+
+        //접수 종료가 대회 일자보다 늦을 수 없도록 예외 처리
+        if (eventDate.isBefore(registrationEndAt.toLocalDate())) {
+            throw new CustomException(ErrorCode.MARATHON_REGISTER_END_EVENT_ERROR);
         }
 
         long daysBetweenStartAndEnd =
                 java.time.Duration.between(registrationStartAt, registrationEndAt).toDays();
 
         if (daysBetweenStartAndEnd < minDaysBetweenStartAndEnd) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new CustomException(ErrorCode.MARATHON_REGISTER_SCHEDULE_ERROR);
         }
 
         long daysBetweenEndAndEvent =
                 java.time.Duration.between(registrationEndAt, eventDate.atStartOfDay()).toDays();
 
         if (daysBetweenEndAndEvent < minDaysBetweenEndAndEvent) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new CustomException(ErrorCode.MARATHON_EVENT_SCHEDULE_ERROR);
         }
 
 

--- a/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/rungo/api/global/exception/ErrorCode.java
@@ -35,6 +35,13 @@ public enum ErrorCode {
     MARATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 대회가 존재합니다."),
     MARATHON_CANCELED(HttpStatus.BAD_REQUEST, "취소된 대회입니다."),
     MARATHON_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 대회입니다."),
+    MARATHON_REGISTER_START_END_ERROR(HttpStatus.BAD_REQUEST, "대회 접수시작은 종료일 보다 이전이어야 합니다."),
+    MARATHON_REGISTER_END_EVENT_ERROR(HttpStatus.BAD_REQUEST, "대회 접수 종료일은 대회 보다  이전이어야 합니다."),
+    COURSE_TYPE_DUPLICATE_ERROR(HttpStatus.BAD_REQUEST, "코스 타입이 중복되었습니다."),
+    MARATHON_MODIFY_AFTER_REGISTER_START(HttpStatus.BAD_REQUEST, "접수 시작 후, 대회 정보를 수정할 수 없습니다."),
+    COURSE_ID_DUPLICATE_ERROR(HttpStatus.BAD_REQUEST, "동일한 코스정보가 이미 존재합니다."),
+    MARATHON_REGISTER_SCHEDULE_ERROR(HttpStatus.BAD_REQUEST, "접수 시작일은 접수 종료일보다 24시간 이전이어야 합니다."),
+    MARATHON_EVENT_SCHEDULE_ERROR(HttpStatus.BAD_REQUEST, "대회 시작일은 접수 종료일보다 24시간 이후이어야 합니다."),
 
     // 마라톤, 접수
     MARATHON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마라톤 대회를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #201 

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [ ] 마라톤 CRUD API 내에서 에러 코드 세분화
- [ ] 날짜 유효성 검사 함수를 이용


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트
마라톤 생성시, 날짜 유효성 검사 함수를 이용하여 코드 중복 최소화
마라톤 수정시 사용하는 날짜 유효성 검사 함수에도 해당 함수 이용.
마라톤 CRUD 에러를 세분화 하여 UX 개선, 디버깅 최적화

## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [ ] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [ ] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?